### PR TITLE
feat: support creation of WlRegion, used for setting input region

### DIFF
--- a/layershellev/examples/simplelayer.rs
+++ b/layershellev/examples/simplelayer.rs
@@ -34,6 +34,17 @@ fn main() {
                         .unwrap(),
                 );
                 println!("{:?}", virtual_keyboard_manager);
+                ReturnData::RequestCompositor
+            },
+            LayerEvent::CompositorProvide(compositor, qh) => {
+                // NOTE: you can set input region to limit area which gets input events
+                // surface outside region becomes transparent for input events
+                // To ignore all input events use region with (0,0) size
+                for x in ev.get_unit_iter() {
+                    let region = compositor.create_region(&qh, ());
+                    region.add(0, 0, 0, 0);
+                    x.get_wlsurface().set_input_region(Some(&region));
+                }
                 ReturnData::None
             }
             LayerEvent::XdgInfoChanged(_) => {

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -7,6 +7,7 @@ use wayland_client::{
     globals::GlobalList,
     protocol::{
         wl_buffer::WlBuffer,
+        wl_compositor::WlCompositor,
         wl_output::WlOutput,
         wl_pointer::{self, ButtonState, WlPointer},
         wl_shm::WlShm,
@@ -46,6 +47,10 @@ pub enum LayerEvent<'a, T, Message> {
     /// event is [LayerEvent::BindProvide], you can use the GlobalList and QueueHandle to create
     /// new wayland objects.
     BindProvide(&'a GlobalList, &'a QueueHandle<WindowState<T>>),
+    /// After you return [ReturnData::RequestCompositor] in the init stage, next
+    /// event is [LayerEvent::CompositorProvide], you can use the WlCompositor and QueueHandle to
+    /// create new wayland objects.
+    CompositorProvide(&'a WlCompositor, &'a QueueHandle<WindowState<T>>),
     /// create a new buffer after request. if you use display_handle, you do not need to care about
     /// it.
     RequestBuffer(
@@ -108,7 +113,7 @@ impl Default for NewLayerShellSettings {
 /// Note: when receive InitRequest, you can request to bind extra wayland-protocols. this time you
 /// can bind virtual-keyboard. you can take startcolorkeyboard as reference, or the simple.rs. Also,
 /// it should can bind with text-input, but I am not fully understand about this, maybe someone
-/// famillar with it can do
+/// familiar with it can do
 ///
 /// When send RequestExist, it will tell the event to finish.
 ///
@@ -121,6 +126,7 @@ pub enum ReturnData<INFO> {
     WlBuffer(WlBuffer),
     RequestBind,
     RequestExist,
+    RequestCompositor,
     RedrawAllRequest,
     RedrawIndexRequest(Id),
     RequestSetCursorShape((String, WlPointer, u32)),

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -140,6 +140,7 @@ use wayland_client::{
         wl_keyboard::{self, KeyState, KeymapFormat, WlKeyboard},
         wl_output::{self, WlOutput},
         wl_pointer::{self, WlPointer},
+        wl_region::WlRegion,
         wl_registry,
         wl_seat::{self, WlSeat},
         wl_shm::WlShm,
@@ -1553,6 +1554,7 @@ delegate_noop!(@<T> WindowState<T>: ignore WlOutput); // output is need to place
 delegate_noop!(@<T> WindowState<T>: ignore WlShm); // shm is used to create buffer pool
 delegate_noop!(@<T> WindowState<T>: ignore WlShmPool); // so it is pool, created by wl_shm
 delegate_noop!(@<T> WindowState<T>: ignore WlBuffer); // buffer show the picture
+delegate_noop!(@<T> WindowState<T>: ignore WlRegion); // region is used to modify input region
 delegate_noop!(@<T> WindowState<T>: ignore ZwlrLayerShellV1); // it is similar with xdg_toplevel, also the
                                                               // ext-session-shell
 
@@ -1820,6 +1822,13 @@ impl<T: 'static> WindowState<T> {
                 Some(ReturnData::RequestBind) => {
                     init_event = Some(event_handler(
                         LayerEvent::BindProvide(&globals, &qh),
+                        &mut self,
+                        None,
+                    ));
+                }
+                Some(ReturnData::RequestCompositor) => {
+                    init_event = Some(event_handler(
+                        LayerEvent::CompositorProvide(&wmcompositer, &qh),
                         &mut self,
                         None,
                     ));


### PR DESCRIPTION
I wanted to create overlay "transparent"  for mouse/input events, but wasn't able to create WlRegion. 