### PR TITLE
Added basic support for input_regions

### DIFF
--- a/iced_layershell/README.md
+++ b/iced_layershell/README.md
@@ -468,4 +468,83 @@ impl Counter {
 
 ```
 
+### Dynamically set input region
+```rust, no_run
+
+use iced::widget::{button, row, Space};
+use iced::{Color, Element, Length, Task as Command, Theme};
+use iced_layershell::settings::{LayerShellSettings, Settings};
+use iced_layershell::to_layer_message;
+use iced_layershell::Application;
+
+pub fn main() -> Result<(), iced_layershell::Error> {
+    InputRegionExample::run(Settings {
+        layer_settings: LayerShellSettings {
+            size: Some((400, 400)),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+struct InputRegionExample;
+
+#[to_layer_message]
+#[derive(Debug, Clone)]
+#[doc = "Some docs"]
+enum Message {
+    SetRegion,
+    UnsetRegion,
+}
+
+impl Application for InputRegionExample {
+    type Message = Message;
+    type Flags = ();
+    type Theme = Theme;
+    type Executor = iced::executor::Default;
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (Self, Command::none())
+    }
+
+    fn namespace(&self) -> String {
+        String::from("Counter - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::SetRegion => Command::done(Message::SetInputRegion(|region| {
+                // Only the buttons!
+                region.add(0, 0, 400, 70);
+            })),
+            Message::UnsetRegion => Command::done(Message::SetInputRegion(|region| {
+                // Entire window!
+                region.add(0, 0, 400, 400);
+            })),
+            _ => unreachable!(),
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        // Create the top row with two buttons
+        row![
+            button("Set region").on_press(Message::SetRegion),
+            Space::with_width(Length::Fill),
+            button("Reset region").on_press(Message::UnsetRegion),
+        ]
+        .padding(20)
+        .spacing(10)
+        .width(Length::Fill)
+        .into()
+    }
+
+    fn style(&self, theme: &Self::Theme) -> iced_layershell::Appearance {
+        use iced_layershell::Appearance;
+        Appearance {
+            background_color: Color::from_rgba(0.3, 0.3, 0.3, 0.3),
+            text_color: theme.palette().text,
+        }
+    }
+}
+```
 For more example, please take a look at [exwlshelleventloop](https://github.com/waycrate/exwlshelleventloop)

--- a/iced_layershell/README.md
+++ b/iced_layershell/README.md
@@ -471,10 +471,10 @@ impl Counter {
 # Input Regions
 You can define which regions of your window receive input events and which parts are transparent to these events by using WlRegion in SetInputRegion message call.
 ```rust, ignore
-Message::SetInputRegion(|region| {
+Message::SetInputRegion(ActionCallback::new(|region| {
         region.add(0, 0, 400, 400);
         region.subtract(0, 0, 400, 60);
-})
+}))
 ```
 view the full example [here](https://github.com/waycrate/exwlshelleventloop/tree/master/iced_layershell/examples/input_regions.rs)
 

--- a/iced_layershell/README.md
+++ b/iced_layershell/README.md
@@ -468,83 +468,14 @@ impl Counter {
 
 ```
 
-### Dynamically set input region
-```rust, no_run
-
-use iced::widget::{button, row, Space};
-use iced::{Color, Element, Length, Task as Command, Theme};
-use iced_layershell::settings::{LayerShellSettings, Settings};
-use iced_layershell::to_layer_message;
-use iced_layershell::Application;
-
-pub fn main() -> Result<(), iced_layershell::Error> {
-    InputRegionExample::run(Settings {
-        layer_settings: LayerShellSettings {
-            size: Some((400, 400)),
-            ..Default::default()
-        },
-        ..Default::default()
-    })
-}
-
-struct InputRegionExample;
-
-#[to_layer_message]
-#[derive(Debug, Clone)]
-#[doc = "Some docs"]
-enum Message {
-    SetRegion,
-    UnsetRegion,
-}
-
-impl Application for InputRegionExample {
-    type Message = Message;
-    type Flags = ();
-    type Theme = Theme;
-    type Executor = iced::executor::Default;
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
-        (Self, Command::none())
-    }
-
-    fn namespace(&self) -> String {
-        String::from("Counter - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
-        match message {
-            Message::SetRegion => Command::done(Message::SetInputRegion(|region| {
-                // Only the buttons!
-                region.add(0, 0, 400, 70);
-            })),
-            Message::UnsetRegion => Command::done(Message::SetInputRegion(|region| {
-                // Entire window!
-                region.add(0, 0, 400, 400);
-            })),
-            _ => unreachable!(),
-        }
-    }
-
-    fn view(&self) -> Element<Message> {
-        // Create the top row with two buttons
-        row![
-            button("Set region").on_press(Message::SetRegion),
-            Space::with_width(Length::Fill),
-            button("Reset region").on_press(Message::UnsetRegion),
-        ]
-        .padding(20)
-        .spacing(10)
-        .width(Length::Fill)
-        .into()
-    }
-
-    fn style(&self, theme: &Self::Theme) -> iced_layershell::Appearance {
-        use iced_layershell::Appearance;
-        Appearance {
-            background_color: Color::from_rgba(0.3, 0.3, 0.3, 0.3),
-            text_color: theme.palette().text,
-        }
-    }
-}
+# Input Regions
+You can define which regions of your window receive input events and which parts are transparent to these events by using WlRegion in SetInputRegion message call.
+```rust, ignore
+Message::SetInputRegion(|region| {
+        region.add(0, 0, 400, 400);
+        region.subtract(0, 0, 400, 60);
+})
 ```
+view the full example [here](https://github.com/waycrate/exwlshelleventloop/tree/master/iced_layershell/examples/input_regions.rs)
+
 For more example, please take a look at [exwlshelleventloop](https://github.com/waycrate/exwlshelleventloop)

--- a/iced_layershell/examples/input_regions.rs
+++ b/iced_layershell/examples/input_regions.rs
@@ -1,0 +1,75 @@
+use iced::widget::{button, row, Space};
+use iced::{Color, Element, Length, Task as Command, Theme};
+use iced_layershell::settings::{LayerShellSettings, Settings};
+use iced_layershell::to_layer_message;
+use iced_layershell::Application;
+
+pub fn main() -> Result<(), iced_layershell::Error> {
+    InputRegionExample::run(Settings {
+        layer_settings: LayerShellSettings {
+            size: Some((400, 400)),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+struct InputRegionExample;
+
+#[to_layer_message]
+#[derive(Debug, Clone)]
+#[doc = "Some docs"]
+enum Message {
+    SetRegion,
+    UnsetRegion,
+}
+
+impl Application for InputRegionExample {
+    type Message = Message;
+    type Flags = ();
+    type Theme = Theme;
+    type Executor = iced::executor::Default;
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (Self, Command::none())
+    }
+
+    fn namespace(&self) -> String {
+        String::from("Counter - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::SetRegion => Command::done(Message::SetInputRegion(|region| {
+                // Only the buttons!
+                region.add(0, 0, 400, 70);
+            })),
+            Message::UnsetRegion => Command::done(Message::SetInputRegion(|region| {
+                // Entire window!
+                region.add(0, 0, 400, 400);
+            })),
+            _ => unreachable!(),
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        // Create the top row with two buttons
+        row![
+            button("Set region").on_press(Message::SetRegion),
+            Space::with_width(Length::Fill),
+            button("Reset region").on_press(Message::UnsetRegion),
+        ]
+        .padding(20)
+        .spacing(10)
+        .width(Length::Fill)
+        .into()
+    }
+
+    fn style(&self, theme: &Self::Theme) -> iced_layershell::Appearance {
+        use iced_layershell::Appearance;
+        Appearance {
+            background_color: Color::from_rgba(0.3, 0.3, 0.3, 0.3),
+            text_color: theme.palette().text,
+        }
+    }
+}

--- a/iced_layershell/examples/input_regions.rs
+++ b/iced_layershell/examples/input_regions.rs
@@ -1,5 +1,6 @@
 use iced::widget::{button, row, Space};
 use iced::{Color, Element, Length, Task as Command, Theme};
+use iced_layershell::actions::ActionCallback;
 use iced_layershell::settings::{LayerShellSettings, Settings};
 use iced_layershell::to_layer_message;
 use iced_layershell::Application;
@@ -14,7 +15,8 @@ pub fn main() -> Result<(), iced_layershell::Error> {
     })
 }
 
-struct InputRegionExample;
+#[derive(Copy, Clone)]
+struct InputRegionExample(pub bool);
 
 #[to_layer_message]
 #[derive(Debug, Clone)]
@@ -31,7 +33,7 @@ impl Application for InputRegionExample {
     type Executor = iced::executor::Default;
 
     fn new(_flags: ()) -> (Self, Command<Message>) {
-        (Self, Command::none())
+        (Self(false), Command::none())
     }
 
     fn namespace(&self) -> String {
@@ -40,14 +42,21 @@ impl Application for InputRegionExample {
 
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
-            Message::SetRegion => Command::done(Message::SetInputRegion(|region| {
-                // Only the buttons!
-                region.add(0, 0, 400, 70);
-            })),
-            Message::UnsetRegion => Command::done(Message::SetInputRegion(|region| {
-                // Entire window!
-                region.add(0, 0, 400, 400);
-            })),
+            Message::SetRegion => {
+                self.0 = !self.0;
+                let val = self.0;
+                Command::done(Message::SetInputRegion(ActionCallback::new(
+                    move |region| {
+                        if val {
+                            // Only the buttons!
+                            region.add(0, 0, 400, 70);
+                        } else {
+                            // Entire Screen
+                            region.add(0, 0, 400, 400);
+                        }
+                    },
+                )))
+            }
             _ => unreachable!(),
         }
     }

--- a/iced_layershell/examples/input_regions.rs
+++ b/iced_layershell/examples/input_regions.rs
@@ -1,4 +1,4 @@
-use iced::widget::{button, row, Space};
+use iced::widget::{button, row};
 use iced::{Color, Element, Length, Task as Command, Theme};
 use iced_layershell::actions::ActionCallback;
 use iced_layershell::settings::{LayerShellSettings, Settings};
@@ -23,7 +23,6 @@ struct InputRegionExample(pub bool);
 #[doc = "Some docs"]
 enum Message {
     SetRegion,
-    UnsetRegion,
 }
 
 impl Application for InputRegionExample {
@@ -37,7 +36,7 @@ impl Application for InputRegionExample {
     }
 
     fn namespace(&self) -> String {
-        String::from("Counter - Iced")
+        String::from("Custom input regions")
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {
@@ -48,7 +47,7 @@ impl Application for InputRegionExample {
                 Command::done(Message::SetInputRegion(ActionCallback::new(
                     move |region| {
                         if val {
-                            // Only the buttons!
+                            // Only the button
                             region.add(0, 0, 400, 70);
                         } else {
                             // Entire Screen
@@ -62,11 +61,9 @@ impl Application for InputRegionExample {
     }
 
     fn view(&self) -> Element<Message> {
-        // Create the top row with two buttons
         row![
-            button("Set region").on_press(Message::SetRegion),
-            Space::with_width(Length::Fill),
-            button("Reset region").on_press(Message::UnsetRegion),
+            button(if self.0 { "Set region" } else { "Reset region" })
+            .on_press(Message::SetRegion)
         ]
         .padding(20)
         .spacing(10)

--- a/iced_layershell/src/actions.rs
+++ b/iced_layershell/src/actions.rs
@@ -1,4 +1,4 @@
-use crate::reexport::{Anchor, Layer};
+use crate::reexport::{Anchor, Layer, WlRegion};
 use iced::window::Id as IcedId;
 use iced_core::mouse::Interaction;
 use layershellev::id::Id as LayerId;
@@ -69,6 +69,7 @@ pub enum LayershellCustomActions {
         settings: NewLayerShellSettings,
         id: IcedId,
     },
+    SetInputRegion(fn(&WlRegion)),
     NewPopUp {
         settings: IcedNewPopupSettings,
         id: IcedId,

--- a/iced_layershell/src/actions.rs
+++ b/iced_layershell/src/actions.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 pub(crate) type LayerShellActionVec = Vec<LayerShellAction>;
 
+#[derive(Debug, Clone)]
 pub(crate) enum LayerShellAction {
     Mouse(Interaction),
     CustomActions(LayershellCustomActions),
@@ -75,6 +76,7 @@ impl ActionCallback {
 
 /// NOTE: DO NOT USE THIS ENUM DIERCTLY
 /// use macro to_layer_message
+#[derive(Debug, Clone)]
 pub enum LayershellCustomActions {
     AnchorChange(Anchor),
     LayerChange(Layer),
@@ -104,6 +106,9 @@ pub enum LayershellCustomActions {
     ForgetLastOutput,
 }
 
+/// Please do not use this struct directly
+/// Use macro to_layer_message instead
+#[derive(Debug, Clone)]
 pub struct LayershellCustomActionsWithId(pub Option<IcedId>, pub LayershellCustomActions);
 
 impl LayershellCustomActionsWithId {
@@ -113,6 +118,7 @@ impl LayershellCustomActionsWithId {
 }
 
 // first one means
+#[derive(Debug, Clone)]
 pub(crate) struct LayershellCustomActionsWithIdInner(
     pub Option<LayerId>,         // come from
     pub Option<LayerId>,         // target if has one

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -284,9 +284,9 @@ where
                         let height: i32 = window_size.1.try_into().unwrap_or_default();
 
                         region.subtract(0, 0, width, height);
-                        set_region(&region);
+                        set_region(region);
 
-                        window.get_wlsurface().set_input_region(Some(&region));
+                        window.get_wlsurface().set_input_region(Some(region));
                     }
                     LayershellCustomActions::MarginChange(margin) => {
                         ev.main_window().set_margin(margin);

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -208,10 +208,10 @@ where
                 def_returndata = ReturnData::RequestBind;
             }
             LayerEvent::BindProvide(globals, qh) => {
-                let wl_compositor = globals.bind::<WlCompositor, _, _>(qh, 1..=1, ());
-                if let Ok(wl_compositor) = wl_compositor {
-                    wl_input_region = Some(wl_compositor.create_region(qh, ()));
-                }
+                let wl_compositor = globals
+                    .bind::<WlCompositor, _, _>(qh, 1..=1, ())
+                    .expect("could not bind wl_compositor");
+                wl_input_region = Some(wl_compositor.create_region(qh, ()));
 
                 if settings.virtual_keyboard_support.is_some() {
                     let virtual_keyboard_manager = globals

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -278,18 +278,15 @@ where
                     LayershellCustomActions::SetInputRegion(set_region) => {
                         let window = ev.main_window();
 
-                        if let Some(region) = &wl_input_region {
-                            let window_size = window.get_size();
-                            let width: i32 = window_size.0.try_into().unwrap_or_default();
-                            let height: i32 = window_size.1.try_into().unwrap_or_default();
+                        let region = wl_input_region.as_ref().expect("region not found");
+                        let window_size = window.get_size();
+                        let width: i32 = window_size.0.try_into().unwrap_or_default();
+                        let height: i32 = window_size.1.try_into().unwrap_or_default();
 
-                            region.subtract(0, 0, width, height);
-                            set_region(region);
-                        }
+                        region.subtract(0, 0, width, height);
+                        set_region(&region);
 
-                        window
-                            .get_wlsurface()
-                            .set_input_region(wl_input_region.as_ref());
+                        window.get_wlsurface().set_input_region(Some(&region));
                     }
                     LayershellCustomActions::MarginChange(margin) => {
                         ev.main_window().set_margin(margin);

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -22,6 +22,7 @@ use iced_futures::{Executor, Runtime, Subscription};
 
 use layershellev::{
     calloop::timer::{TimeoutAction, Timer},
+    reexport::wayland_client::{WlCompositor, WlRegion},
     reexport::zwp_virtual_keyboard_v1,
     LayerEvent, ReturnData, StartMode, WindowWrapper,
 };
@@ -196,7 +197,7 @@ where
     ));
 
     let mut context = task::Context::from_waker(task::noop_waker_ref());
-
+    let mut wl_input_region: Option<WlRegion> = None;
     let mut pointer_serial: u32 = 0;
 
     let _ = ev.running_with_proxy(message_receiver, move |event, ev, _| {
@@ -204,28 +205,33 @@ where
         let mut def_returndata = ReturnData::None;
         match event {
             LayerEvent::InitRequest => {
-                if settings.virtual_keyboard_support.is_some() {
-                    def_returndata = ReturnData::RequestBind;
-                }
+                def_returndata = ReturnData::RequestBind;
             }
             LayerEvent::BindProvide(globals, qh) => {
-                let virtual_keyboard_manager = globals
-                    .bind::<zwp_virtual_keyboard_v1::ZwpVirtualKeyboardManagerV1, _, _>(
-                        qh,
-                        1..=1,
-                        (),
-                    )
-                    .expect("no support virtual_keyboard");
-                let VirtualKeyboardSettings {
-                    file,
-                    keymap_size,
-                    keymap_format,
-                } = settings.virtual_keyboard_support.as_ref().unwrap();
-                let seat = ev.get_seat();
-                let virtual_keyboard_in =
-                    virtual_keyboard_manager.create_virtual_keyboard(seat, qh, ());
-                virtual_keyboard_in.keymap((*keymap_format).into(), file.as_fd(), *keymap_size);
-                ev.set_virtual_keyboard(virtual_keyboard_in);
+                let wl_compositor = globals.bind::<WlCompositor, _, _>(qh, 1..=1, ());
+                if let Ok(wl_compositor) = wl_compositor {
+                    wl_input_region = Some(wl_compositor.create_region(qh, ()));
+                }
+
+                if settings.virtual_keyboard_support.is_some() {
+                    let virtual_keyboard_manager = globals
+                        .bind::<zwp_virtual_keyboard_v1::ZwpVirtualKeyboardManagerV1, _, _>(
+                            qh,
+                            1..=1,
+                            (),
+                        )
+                        .expect("no support virtual_keyboard");
+                    let VirtualKeyboardSettings {
+                        file,
+                        keymap_size,
+                        keymap_format,
+                    } = settings.virtual_keyboard_support.as_ref().unwrap();
+                    let seat = ev.get_seat();
+                    let virtual_keyboard_in =
+                        virtual_keyboard_manager.create_virtual_keyboard(seat, qh, ());
+                    virtual_keyboard_in.keymap((*keymap_format).into(), file.as_fd(), *keymap_size);
+                    ev.set_virtual_keyboard(virtual_keyboard_in);
+                }
             }
             LayerEvent::RequestMessages(message) => {
                 if let DispatchMessage::MouseEnter { serial, .. } = message {
@@ -268,6 +274,22 @@ where
                     }
                     LayershellCustomActions::LayerChange(layer) => {
                         ev.main_window().set_layer(layer);
+                    }
+                    LayershellCustomActions::SetInputRegion(set_region) => {
+                        let window = ev.main_window();
+
+                        if let Some(region) = &wl_input_region {
+                            let window_size = window.get_size();
+                            let width: i32 = window_size.0.try_into().unwrap_or_default();
+                            let height: i32 = window_size.1.try_into().unwrap_or_default();
+
+                            region.subtract(0, 0, width, height);
+                            set_region(region);
+                        }
+
+                        window
+                            .get_wlsurface()
+                            .set_input_region(wl_input_region.as_ref());
                     }
                     LayershellCustomActions::MarginChange(margin) => {
                         ev.main_window().set_margin(margin);

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -27,10 +27,9 @@ use layershellev::{
     LayerEvent, ReturnData, StartMode, WindowWrapper,
 };
 
-use crate::actions::ActionCallback;
 use futures::{channel::mpsc, StreamExt};
 
-use crate::{event::IcedLayerEvent, proxy::IcedProxy, settings::Settings};
+use crate::{actions::ActionCallback, event::IcedLayerEvent, proxy::IcedProxy, settings::Settings};
 
 /// An interactive, native cross-platform application.
 ///

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -27,6 +27,7 @@ use layershellev::{
     LayerEvent, ReturnData, StartMode, WindowWrapper,
 };
 
+use crate::actions::ActionCallback;
 use futures::{channel::mpsc, StreamExt};
 
 use crate::{event::IcedLayerEvent, proxy::IcedProxy, settings::Settings};
@@ -275,7 +276,7 @@ where
                     LayershellCustomActions::LayerChange(layer) => {
                         ev.main_window().set_layer(layer);
                     }
-                    LayershellCustomActions::SetInputRegion(set_region) => {
+                    LayershellCustomActions::SetInputRegion(ActionCallback(set_region)) => {
                         let window = ev.main_window();
 
                         let region = wl_input_region.as_ref().expect("region not found");

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -35,7 +35,6 @@ use iced_futures::Subscription;
 pub use sandbox::LayerShellSandbox;
 
 pub type Result = std::result::Result<(), error::Error>;
-
 /// The appearance of a program.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Appearance {

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -13,7 +13,7 @@ mod sandbox;
 pub mod settings;
 
 pub mod reexport {
-    pub use layershellev::reexport::wayland_client::wl_keyboard;
+    pub use layershellev::reexport::wayland_client::{wl_keyboard, WlRegion};
     pub use layershellev::reexport::Anchor;
     pub use layershellev::reexport::KeyboardInteractivity;
     pub use layershellev::reexport::Layer;

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -32,6 +32,7 @@ use iced_futures::{Executor, Runtime, Subscription};
 
 use layershellev::{
     calloop::timer::{TimeoutAction, Timer},
+    reexport::wayland_client::{WlCompositor, WlRegion},
     reexport::zwp_virtual_keyboard_v1,
     LayerEvent, NewPopUpSettings, ReturnData, WindowState, WindowWrapper,
 };
@@ -210,6 +211,7 @@ where
     let mut context = task::Context::from_waker(task::noop_waker_ref());
 
     let mut pointer_serial: u32 = 0;
+    let mut wl_input_region: Option<WlRegion> = None;
 
     let _ = ev.running_with_proxy(message_receiver, move |event, ev, index| {
         use layershellev::DispatchMessage;
@@ -219,28 +221,33 @@ where
             .map(|unit| unit.id());
         match event {
             LayerEvent::InitRequest => {
-                if settings.virtual_keyboard_support.is_some() {
-                    def_returndata = ReturnData::RequestBind;
-                }
+                def_returndata = ReturnData::RequestBind;
             }
             LayerEvent::BindProvide(globals, qh) => {
-                let virtual_keyboard_manager = globals
-                    .bind::<zwp_virtual_keyboard_v1::ZwpVirtualKeyboardManagerV1, _, _>(
-                        qh,
-                        1..=1,
-                        (),
-                    )
-                    .expect("no support virtual_keyboard");
-                let VirtualKeyboardSettings {
-                    file,
-                    keymap_size,
-                    keymap_format,
-                } = settings.virtual_keyboard_support.as_ref().unwrap();
-                let seat = ev.get_seat();
-                let virtual_keyboard_in =
-                    virtual_keyboard_manager.create_virtual_keyboard(seat, qh, ());
-                virtual_keyboard_in.keymap((*keymap_format).into(), file.as_fd(), *keymap_size);
-                ev.set_virtual_keyboard(virtual_keyboard_in);
+                let wl_compositor = globals.bind::<WlCompositor, _, _>(qh, 1..=1, ());
+                if let Ok(wl_compositor) = wl_compositor {
+                    wl_input_region = Some(wl_compositor.create_region(qh, ()));
+                }
+
+                if settings.virtual_keyboard_support.is_some() {
+                    let virtual_keyboard_manager = globals
+                        .bind::<zwp_virtual_keyboard_v1::ZwpVirtualKeyboardManagerV1, _, _>(
+                            qh,
+                            1..=1,
+                            (),
+                        )
+                        .expect("no support virtual_keyboard");
+                    let VirtualKeyboardSettings {
+                        file,
+                        keymap_size,
+                        keymap_format,
+                    } = settings.virtual_keyboard_support.as_ref().unwrap();
+                    let seat = ev.get_seat();
+                    let virtual_keyboard_in =
+                        virtual_keyboard_manager.create_virtual_keyboard(seat, qh, ());
+                    virtual_keyboard_in.keymap((*keymap_format).into(), file.as_fd(), *keymap_size);
+                    ev.set_virtual_keyboard(virtual_keyboard_in);
+                }
             }
             LayerEvent::RequestMessages(message) => 'outside: {
                 match message {
@@ -354,6 +361,28 @@ where
                                 break 'out;
                             };
                             window.set_size((width, height));
+                        }
+                        LayershellCustomActions::SetInputRegion(set_region) => {
+                            let Some(id) = id else {
+                                break 'out;
+                            };
+                            let Some(window) = ev.get_window_with_id(id) else {
+                                break 'out;
+                            };
+                            let Some(region) = &wl_input_region else {
+                                break 'out;
+                            };
+
+                            let window_size = window.get_size();
+                            let width: i32 = window_size.0.try_into().unwrap_or_default();
+                            let height: i32 = window_size.1.try_into().unwrap_or_default();
+
+                            region.subtract(0, 0, width, height);
+                            set_region(region);
+
+                            window
+                                .get_wlsurface()
+                                .set_input_region(wl_input_region.as_ref());
                         }
                         LayershellCustomActions::VirtualKeyboardPressed { time, key } => {
                             use layershellev::reexport::wayland_client::KeyState;

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -224,10 +224,10 @@ where
                 def_returndata = ReturnData::RequestBind;
             }
             LayerEvent::BindProvide(globals, qh) => {
-                let wl_compositor = globals.bind::<WlCompositor, _, _>(qh, 1..=1, ());
-                if let Ok(wl_compositor) = wl_compositor {
-                    wl_input_region = Some(wl_compositor.create_region(qh, ()));
-                }
+                let wl_compositor = globals
+                    .bind::<WlCompositor, _, _>(qh, 1..=1, ())
+                    .expect("could not bind wl_compositor");
+                wl_input_region = Some(wl_compositor.create_region(qh, ()));
 
                 if settings.virtual_keyboard_support.is_some() {
                     let virtual_keyboard_manager = globals

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -363,6 +363,7 @@ where
                             window.set_size((width, height));
                         }
                         LayershellCustomActions::SetInputRegion(set_region) => {
+                            let set_region = set_region.0;
                             let Some(id) = id else {
                                 break 'out;
                             };

--- a/iced_layershell_macros/src/lib.rs
+++ b/iced_layershell_macros/src/lib.rs
@@ -38,7 +38,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
         true => {
             let additional_variants = quote! {
                 AnchorChange{id: iced::window::Id, anchor: iced_layershell::reexport::Anchor},
-                SetInputRegion{ id: iced::window::Id, set_region: fn(&iced_layershell::reexport::WlRegion) },
+                SetInputRegion{ id: iced::window::Id, callback: iced_layershell::actions::ActionCallback },
                 AnchorSizeChange{id: iced::window::Id, anchor:iced_layershell::reexport::Anchor, size: (u32, u32)},
                 LayerChange{id: iced::window::Id, layer:iced_layershell::reexport::Layer},
                 MarginChange{id: iced::window::Id, margin: (i32, i32, i32, i32)},
@@ -62,7 +62,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                         use iced_layershell::actions::LayershellCustomActionsWithId;
 
                         match self {
-                            Self::SetInputRegion{ id, set_region } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::SetInputRegion(set_region))),
+                            Self::SetInputRegion{ id, callback } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::SetInputRegion(callback))),
                             Self::AnchorChange { id, anchor } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::AnchorChange(anchor))),
                             Self::AnchorSizeChange { id, anchor, size } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::AnchorSizeChange(anchor, size))),
                             Self::LayerChange { id, layer } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::LayerChange(layer))),
@@ -113,7 +113,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
         false => {
             let additional_variants = quote! {
                 AnchorChange(iced_layershell::reexport::Anchor),
-                SetInputRegion(fn(&iced_layershell::reexport::WlRegion)),
+                SetInputRegion(iced_layershell::actions::ActionCallback),
                 AnchorSizeChange(iced_layershell::reexport::Anchor, (u32, u32)),
                 LayerChange(iced_layershell::reexport::Layer),
                 MarginChange((i32, i32, i32, i32)),
@@ -131,7 +131,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                         use iced_layershell::actions::LayershellCustomActions;
 
                         match self {
-                            Self::SetInputRegion(region) => Ok(LayershellCustomActions::SetInputRegion(region)),
+                            Self::SetInputRegion(callback) => Ok(LayershellCustomActions::SetInputRegion(callback)),
                             Self::AnchorChange(anchor) => Ok(LayershellCustomActions::AnchorChange(anchor)),
                             Self::AnchorSizeChange(anchor, size) => Ok(LayershellCustomActions::AnchorSizeChange(anchor, size)),
                             Self::LayerChange(layer) => Ok(LayershellCustomActions::LayerChange(layer)),

--- a/iced_layershell_macros/src/lib.rs
+++ b/iced_layershell_macros/src/lib.rs
@@ -38,6 +38,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
         true => {
             let additional_variants = quote! {
                 AnchorChange{id: iced::window::Id, anchor: iced_layershell::reexport::Anchor},
+                SetInputRegion{ id: iced::window::Id, set_region: fn(&iced_layershell::reexport::WlRegion) },
                 AnchorSizeChange{id: iced::window::Id, anchor:iced_layershell::reexport::Anchor, size: (u32, u32)},
                 LayerChange{id: iced::window::Id, layer:iced_layershell::reexport::Layer},
                 MarginChange{id: iced::window::Id, margin: (i32, i32, i32, i32)},
@@ -61,6 +62,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                         use iced_layershell::actions::LayershellCustomActionsWithId;
 
                         match self {
+                            Self::SetInputRegion{ id, set_region } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::SetInputRegion(set_region))),
                             Self::AnchorChange { id, anchor } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::AnchorChange(anchor))),
                             Self::AnchorSizeChange { id, anchor, size } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::AnchorSizeChange(anchor, size))),
                             Self::LayerChange { id, layer } => Ok(LayershellCustomActionsWithId::new(Some(id), LayershellCustomActions::LayerChange(layer))),
@@ -111,6 +113,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
         false => {
             let additional_variants = quote! {
                 AnchorChange(iced_layershell::reexport::Anchor),
+                SetInputRegion(fn(&iced_layershell::reexport::WlRegion)),
                 AnchorSizeChange(iced_layershell::reexport::Anchor, (u32, u32)),
                 LayerChange(iced_layershell::reexport::Layer),
                 MarginChange((i32, i32, i32, i32)),
@@ -128,6 +131,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                         use iced_layershell::actions::LayershellCustomActions;
 
                         match self {
+                            Self::SetInputRegion(region) => Ok(LayershellCustomActions::SetInputRegion(region)),
                             Self::AnchorChange(anchor) => Ok(LayershellCustomActions::AnchorChange(anchor)),
                             Self::AnchorSizeChange(anchor, size) => Ok(LayershellCustomActions::AnchorSizeChange(anchor, size)),
                             Self::LayerChange(layer) => Ok(LayershellCustomActions::LayerChange(layer)),

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -241,8 +241,10 @@ pub mod reexport {
         pub use wayland_client::{
             globals::GlobalList,
             protocol::{
+                wl_compositor::WlCompositor,
                 wl_keyboard::{self, KeyState},
                 wl_pointer::{self, ButtonState},
+                wl_region::WlRegion,
                 wl_seat::WlSeat,
             },
             QueueHandle, WEnum,


### PR DESCRIPTION
# Attempts to solve #110 
This creates an interface to dynamically set input region, which can be edited by user by means of a new action
```rust
   // Simple application
   LayershellCustomActoin::SetInputRegion(|region| {
            region.add(0, 0, 5000, 5000);
            region.subtract(0, 0, 50, 50);
    }))
   // Multi-Window application
   Message::SetInputRegion { 
      set_region: |region| { 
        region.add(500,500,1920,1080); 
      }, id: WindowId
   }
```
I'm marking this as draft, any suggestions would be much appreciate since its my first time contributing here.
This also adds nessasory changes to to_layer_message macro, and to multi window mode.