### PR TITLE
fix: surface reconfigured every frame

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -524,7 +524,7 @@ async fn run_instance<A, E, C>(
         };
     }
     let mut window_manager: WindowManager<A, C> = WindowManager::new();
-    let mut sizes: HashMap<layershellev::id::Id, iced_core::Size<u32>> = HashMap::new();
+    let mut sizes: HashMap<iced_core::window::Id, iced_core::Size<u32>> = HashMap::new();
 
     let mut clipboard = LayerShellClipboard::unconnected();
     let mut ui_caches: HashMap<window::Id, user_interface::Cache> = HashMap::new();
@@ -685,13 +685,13 @@ async fn run_instance<A, E, C>(
 
                 let physical_size = window.state.physical_size();
 
-                if match sizes.get(&window.id) {
+                if match sizes.get(&id) {
                     None => true,
                     Some(size) => {
                         size.height != physical_size.height || size.width != physical_size.width
                     }
                 } {
-                    sizes.insert(window.id, physical_size);
+                    sizes.insert(id, physical_size);
 
                     compositor.configure_surface(
                         &mut window.surface,
@@ -889,9 +889,7 @@ async fn run_instance<A, E, C>(
                         .collect();
 
                 application.remove_id(id);
-                if let Some(id) = window_manager.get_layer_id(id) {
-                    sizes.remove(&id);
-                };
+                sizes.remove(&id);
                 window_manager.remove(id);
                 cached_user_interfaces.remove(&id);
                 user_interfaces = ManuallyDrop::new(build_user_interfaces(


### PR DESCRIPTION
Cache surface sizes and scale to avoid configuring the surface every frame, this reduces CPU usage.