### PR TITLE
feat(multi_window): send `iced::window::Event::Closed`.

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -919,6 +919,11 @@ async fn run_instance<A, E, C>(
                     &mut window_manager,
                     cached_user_interfaces,
                 ));
+                runtime.broadcast(iced_futures::subscription::Event::Interaction {
+                    window: id,
+                    event: Event::Window(window::Event::Closed),
+                    status: iced_core::event::Status::Ignored,
+                });
                 // if now there is no windows now, then break the compositor, and unlink the clipboard
                 if window_manager.is_empty() {
                     compositor = None;


### PR DESCRIPTION
Send `iced::window::Event::Closed` after a window is removed. This will be more consistent with the behavior of `iced_winit`. It also make handling after-closed tasks more easily compared to `remove_id`.