### PR TITLE
feat(namespace): allow setting namespace when a new window is opened.

### DIFF
--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -69,7 +69,7 @@ pub enum LayerEvent<'a, T, Message> {
 }
 
 /// layershell settings to create a new layershell surface
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewLayerShellSettings {
     /// the size of the layershell, optional.
     pub size: Option<(u32, u32)>,
@@ -83,6 +83,7 @@ pub struct NewLayerShellSettings {
     /// wl_output.
     pub use_last_output: bool,
     pub events_transparent: bool,
+    pub namespace: Option<String>,
 }
 
 /// be used to create a new popup
@@ -119,6 +120,7 @@ impl Default for NewLayerShellSettings {
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
             use_last_output: false,
             events_transparent: false,
+            namespace: None,
         }
     }
 }

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -2833,6 +2833,7 @@ impl<T: 'static> WindowState<T> {
                                         keyboard_interactivity,
                                         use_last_output,
                                         events_transparent,
+                                        namespace,
                                     },
                                     id,
                                     info,
@@ -2864,7 +2865,7 @@ impl<T: 'static> WindowState<T> {
                                         &wl_surface,
                                         output,
                                         layer,
-                                        window_state.namespace.clone(),
+                                        namespace.clone().unwrap_or_else(|| window_state.namespace.clone()),
                                         &qh,
                                         (),
                                     );

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -2865,7 +2865,7 @@ impl<T: 'static> WindowState<T> {
                                         &wl_surface,
                                         output,
                                         layer,
-                                        namespace.clone().unwrap_or_else(|| window_state.namespace.clone()),
+                                        namespace.unwrap_or_else(|| window_state.namespace.clone()),
                                         &qh,
                                         (),
                                     );


### PR DESCRIPTION
I don't know what actually the `namespace` is used for. But it seems that we can allow the client to specify the `namespace` for each surface.

[wayland protocol](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:enum:layer):
```
Clients can specify a namespace that defines the purpose of the layer surface.
```