### PR TITLE
fix: fix #140.

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -554,13 +554,6 @@ async fn run_instance<A, E, C>(
     let mut should_exit = false;
     let mut messages = Vec::new();
 
-    // record the last window id, when window is removed, we compare the id with the last id, to
-    // find out if the current surface binding with the compositor is dead, if so, update the
-    // compositor with the alive one
-    let mut last_id = None;
-    // mark if compositor needs to be updated
-    let mut compositor_to_be_updated = true;
-
     while let Some(event) = event_receiver.next().await {
         waiting_actions.retain(|(id, custom_action)| {
             let Some(layerid) = window_manager.get_layer_id(*id) else {
@@ -603,8 +596,6 @@ async fn run_instance<A, E, C>(
                     if compositor.is_none() {
                         replace_compositor!(wrapper);
                         clipboard = LayerShellClipboard::connect(&wrapper);
-                        compositor_to_be_updated = false;
-                        last_id = Some(id);
                     }
 
                     let window = window_manager.insert(
@@ -654,15 +645,6 @@ async fn run_instance<A, E, C>(
                             id,
                             ui.relayout(window.state.logical_size(), &mut window.renderer),
                         );
-                    }
-                    // NOTE: if compositor need to be updated, use the first be refreshed one to
-                    // update it
-                    if compositor_to_be_updated {
-                        let wrapper = Arc::new(wrapper);
-                        replace_compositor!(wrapper);
-                        clipboard = LayerShellClipboard::connect(&wrapper);
-                        last_id = Some(id);
-                        compositor_to_be_updated = false;
                     }
                     (id, window)
                 };
@@ -928,18 +910,7 @@ async fn run_instance<A, E, C>(
                 if window_manager.is_empty() {
                     compositor = None;
                     clipboard = LayerShellClipboard::unconnected();
-                    compositor_to_be_updated = true;
-                    continue;
                 }
-
-                // NOTE: if current binding surface is still alive, we do not need to update the
-                // compositor
-                if let Some(last_id) = last_id {
-                    if last_id != id {
-                        continue;
-                    }
-                }
-                compositor_to_be_updated = true;
             }
             MultiWindowIcedLayerEvent(
                 Some(id),


### PR DESCRIPTION
revert `4579a47a6c1f6a571e670693957fc7561106893d` to fix #140.