### PR TITLE
fix: there is no effect on changing the application scale factor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi_window"
+version = "0.13.5"
+dependencies = [
+ "iced",
+ "iced_layershell",
+ "iced_runtime",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mutate_once"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/iced_examples/multi_window/Cargo.toml
+++ b/iced_examples/multi_window/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "multi_window"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+description.workspace = true
+keywords.workspace = true
+readme.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+iced = { workspace = true }
+iced_runtime.workspace = true
+iced_layershell.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/iced_examples/multi_window/src/main.rs
+++ b/iced_examples/multi_window/src/main.rs
@@ -1,0 +1,259 @@
+use iced::alignment::Vertical;
+use iced::widget::{
+    button, center, column, container, horizontal_space, row, scrollable, text, text_input,
+};
+use iced::{Center, Element, Fill, Subscription, Task, Theme, event};
+use iced::{Color, window};
+use iced_layershell::build_pattern::{self, MainSettings};
+use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings};
+use iced_layershell::settings::{LayerShellSettings, StartMode};
+use iced_layershell::{Appearance, DefaultStyle, to_layer_message};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, fmt};
+
+use std::collections::BTreeMap;
+
+fn main() -> iced_layershell::Result {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+    build_pattern::daemon(
+        "multi_window",
+        Example::update,
+        Example::view,
+        Example::remove_id,
+    )
+    .theme(Example::theme)
+    .style(Example::style)
+    .subscription(Example::subscription)
+    .scale_factor(Example::scale_factor)
+    .settings(MainSettings {
+        layer_settings: LayerShellSettings {
+            start_mode: StartMode::Background,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .run_with(Example::new)?;
+    Ok(())
+}
+
+struct Example {
+    windows: BTreeMap<window::Id, Window>,
+}
+
+#[derive(Debug)]
+struct Window {
+    title: String,
+    scale_input: String,
+    current_scale: f64,
+    theme: Theme,
+    transparent: bool,
+}
+
+#[to_layer_message(multi)]
+#[derive(Debug, Clone)]
+enum Message {
+    OpenWindow,
+    CloseWindow(window::Id),
+    WindowOpened(window::Id),
+    WindowClosed(window::Id),
+    ScaleInputChanged(window::Id, String),
+    ScaleChanged(window::Id, String),
+    TitleChanged(window::Id, String),
+}
+
+impl Example {
+    fn open(count: usize) -> (window::Id, Task<Message>) {
+        let anchor = match count % 8 {
+            0 => Anchor::Bottom,
+            1 => Anchor::Bottom | Anchor::Right,
+            2 => Anchor::Right,
+            3 => Anchor::Right | Anchor::Top,
+            4 => Anchor::Top,
+            5 => Anchor::Top | Anchor::Left,
+            6 => Anchor::Left,
+            7 => Anchor::Left | Anchor::Bottom,
+            _ => Anchor::Bottom,
+        };
+        let size = (1024, 768);
+        let id = window::Id::unique();
+        (
+            id,
+            Task::done(Message::NewLayerShell {
+                settings: NewLayerShellSettings {
+                    size: Some(size),
+                    exclusive_zone: None,
+                    anchor,
+                    layer: Layer::Top,
+                    margin: None,
+                    //keyboard_interactivity: KeyboardInteractivity::None,
+                    use_last_output: false,
+                    ..Default::default()
+                },
+                id,
+            }),
+        )
+    }
+
+    fn new() -> (Self, Task<Message>) {
+        let (id, open) = Self::open(0);
+
+        (
+            Self {
+                windows: BTreeMap::new(),
+            },
+            open.chain(Task::done(Message::WindowOpened(id))),
+        )
+    }
+
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::OpenWindow => {
+                let len = self.windows.len();
+                let (id, open) = Self::open(len);
+                open.chain(Task::done(Message::WindowOpened(id)))
+            }
+            Message::CloseWindow(id) => iced::window::close(id),
+            Message::WindowOpened(id) => {
+                let window = Window::new(self.windows.len() + 1);
+                let focus_input = text_input::focus(format!("input-{id}"));
+
+                self.windows.insert(id, window);
+
+                focus_input
+            }
+            Message::WindowClosed(id) => {
+                self.windows.remove(&id);
+
+                if self.windows.is_empty() {
+                    iced::exit()
+                } else {
+                    Task::none()
+                }
+            }
+            Message::ScaleInputChanged(id, scale) => {
+                if let Some(window) = self.windows.get_mut(&id) {
+                    window.scale_input = scale;
+                }
+
+                Task::none()
+            }
+            Message::ScaleChanged(id, scale) => {
+                if let Some(window) = self.windows.get_mut(&id) {
+                    window.current_scale = scale
+                        .parse::<f64>()
+                        .unwrap_or(window.current_scale)
+                        .clamp(0.5, 5.0);
+                }
+
+                Task::none()
+            }
+            Message::TitleChanged(id, title) => {
+                if let Some(window) = self.windows.get_mut(&id) {
+                    window.title = title;
+                }
+
+                Task::none()
+            }
+            _ => Task::none(),
+        }
+    }
+
+    fn view(&self, window_id: window::Id) -> Element<Message> {
+        if let Some(window) = self.windows.get(&window_id) {
+            center(window.view(window_id)).into()
+        } else {
+            horizontal_space().into()
+        }
+    }
+
+    fn theme(&self, window: window::Id) -> Theme {
+        if let Some(window) = self.windows.get(&window) {
+            window.theme.clone()
+        } else {
+            Theme::default()
+        }
+    }
+
+    fn style(&self, theme: &Theme, window: window::Id) -> Appearance {
+        let mut style = theme.default_style();
+        if let Some(window) = self.windows.get(&window) {
+            if window.transparent {
+                style.background_color = Color::TRANSPARENT;
+            }
+        }
+        style
+    }
+
+    fn scale_factor(&self, window: window::Id) -> f64 {
+        self.windows
+            .get(&window)
+            .map(|window| window.current_scale)
+            .unwrap_or(1.0)
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        event::listen_with(|event, status, id| {
+            tracing::debug!("event: {}, {:?}, {:?}", id, status, event);
+            if let iced::Event::Window(iced::window::Event::Closed) = event {
+                Some(Message::WindowClosed(id))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn remove_id(&mut self, _window: window::Id) {
+        // self.windows.remove(&window);
+    }
+}
+
+impl Window {
+    fn new(count: usize) -> Self {
+        Self {
+            title: format!("Window_{}", count),
+            scale_input: "1.0".to_string(),
+            current_scale: 1.0,
+            theme: Theme::ALL[count % Theme::ALL.len()].clone(),
+            transparent: count % 2 == 0,
+        }
+    }
+
+    fn view(&self, id: window::Id) -> Element<Message> {
+        let scale_input = column![
+            text("Window scale factor:"),
+            text_input("Window Scale", &self.scale_input)
+                .on_input(move |msg| { Message::ScaleInputChanged(id, msg) })
+                .on_submit(Message::ScaleChanged(id, self.scale_input.to_string()))
+        ];
+
+        let title_input = column![
+            text("Window title:"),
+            text_input("Window Title", &self.title)
+                .on_input(move |msg| { Message::TitleChanged(id, msg) })
+                .id(format!("input-{id}"))
+        ];
+
+        let new_window_button = button(text("New Window")).on_press(Message::OpenWindow);
+
+        let close_window_button = button(text("Close")).on_press(Message::CloseWindow(id));
+
+        let content = scrollable(
+            column![
+                scale_input,
+                title_input,
+                row![new_window_button, close_window_button]
+                    .spacing(10)
+                    .align_y(Vertical::Center)
+            ]
+            .spacing(50)
+            .width(Fill)
+            .align_x(Center),
+        );
+
+        container(content).center_x(200).into()
+    }
+}

--- a/iced_layershell/src/application/state.rs
+++ b/iced_layershell/src/application/state.rs
@@ -13,6 +13,9 @@ where
 {
     application_scale_factor: f64,
     wayland_scale_factor: f64,
+    /// viewport_logical_size = window_size / application_scale_factor,
+    /// viewport_physical_size = window_size * wayland_scal_factor,
+    window_size: Size<u32>,
     viewport: Viewport,
     viewport_version: usize,
     theme: A::Theme,
@@ -34,17 +37,18 @@ where
         let (width, height) = window.main_window().get_size();
         let wayland_scale_factor = 1.;
 
-        let logical_size = Size::new(width, height);
-        let viewport = viewport(logical_size, wayland_scale_factor, application_scale_factor);
+        let window_size = Size::new(width, height);
+        let viewport = viewport(window_size, wayland_scale_factor, application_scale_factor);
 
         let wpviewport = window
             .gen_mainwindow_wrapper()
             .viewport
             .expect("iced_layershell need viewport support to better wayland dpi");
-        set_wpviewport_destination(&wpviewport, logical_size);
+        set_wpviewport_destination(&wpviewport, window_size);
         Self {
             application_scale_factor,
             wayland_scale_factor,
+            window_size,
             viewport,
             viewport_version: 0,
             theme,
@@ -60,28 +64,26 @@ where
     }
 
     pub fn update_view_port(&mut self, width: u32, height: u32, scale: f64) {
-        let logical_size = Size::new(width, height);
-        if self.logical_size_u32() == logical_size && self.wayland_scale_factor == scale {
+        let window_size = Size::new(width, height);
+        if self.window_size == window_size && self.wayland_scale_factor == scale {
             return;
         }
+        self.window_size = window_size;
         self.wayland_scale_factor = scale;
-        self.resize_viewport(logical_size);
+        self.resize_viewport();
+        set_wpviewport_destination(&self.wpviewport, self.window_size);
     }
 
     pub fn viewport(&self) -> &Viewport {
         &self.viewport
     }
 
-    pub fn physical_size(&self) -> Size<u32> {
-        self.viewport.physical_size()
+    pub fn wayland_scale_factor(&self) -> f64 {
+        self.wayland_scale_factor
     }
 
-    pub fn logical_size(&self) -> Size<f32> {
-        self.viewport.logical_size()
-    }
-
-    pub fn scale_factor(&self) -> f64 {
-        self.viewport.scale_factor()
+    pub fn application_scale_factor(&self) -> f64 {
+        self.application_scale_factor
     }
 
     pub fn text_color(&self) -> Color {
@@ -111,7 +113,10 @@ where
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
             | WindowEvent::TouchDown { x, y, .. } => {
-                self.mouse_position = Some(Point::new(*x as f32, *y as f32));
+                self.mouse_position = Some(Point::new(
+                    (*x / self.application_scale_factor) as f32,
+                    (*y / self.application_scale_factor) as f32,
+                ));
             }
             WindowEvent::ModifiersChanged(modifiers) => {
                 self.modifiers = *modifiers;
@@ -121,7 +126,7 @@ where
                 scale_u32: _,
             } => {
                 self.wayland_scale_factor = *scale_float;
-                self.resize_viewport(self.logical_size_u32());
+                self.resize_viewport();
             }
             _ => {}
         }
@@ -131,52 +136,53 @@ where
         let new_scale_factor = application.scale_factor();
         if self.application_scale_factor != new_scale_factor {
             self.application_scale_factor = new_scale_factor;
-            self.resize_viewport(self.logical_size_u32());
+            self.resize_viewport();
         }
         self.theme = application.theme();
         self.appearance = application.style(&self.theme);
     }
 
-    fn resize_viewport(&mut self, logical_size: Size<u32>) {
+    fn resize_viewport(&mut self) {
+        tracing::debug!(
+            "before resizing viewport, window_size: {:?}, viewport physical size: {:?}, viewport logical size: {:?}",
+            self.window_size,
+            self.viewport.physical_size(),
+            self.viewport.logical_size()
+        );
         self.viewport = viewport(
-            logical_size,
+            self.window_size,
             self.wayland_scale_factor,
             self.application_scale_factor,
         );
+        tracing::debug!(
+            "after resizing viewport, window_size: {:?}, viewport physical size: {:?}, viewport logical size: {:?}, wayland scale factor: {}, application scale factor: {}",
+            self.window_size,
+            self.viewport.physical_size(),
+            self.viewport.logical_size(),
+            self.wayland_scale_factor,
+            self.application_scale_factor
+        );
 
         self.viewport_version = self.viewport_version.wrapping_add(1);
-
-        set_wpviewport_destination(&self.wpviewport, self.logical_size_u32());
-    }
-
-    fn logical_size_u32(&self) -> Size<u32> {
-        // physical_size = (orig_logical_size as f64 * factor).ceil()
-        // logical_sizea = physical_size as f64 / factor as f32
-        // logical_size >= orig_logical_size
-        let logical_size = self.viewport.logical_size();
-        Size::new(
-            logical_size.width.floor() as u32,
-            logical_size.height.floor() as u32,
-        )
     }
 }
 
 fn viewport(
-    logical_size: Size<u32>,
+    window_size: Size<u32>,
     wayland_scale_factor: f64,
     application_scale_factor: f64,
 ) -> Viewport {
     let factor = wayland_scale_factor * application_scale_factor;
     let physical_size = Size::new(
-        (logical_size.width as f64 * factor).ceil() as u32,
-        (logical_size.height as f64 * factor).ceil() as u32,
+        (window_size.width as f64 * wayland_scale_factor).ceil() as u32,
+        (window_size.height as f64 * wayland_scale_factor).ceil() as u32,
     );
     Viewport::with_physical_size(physical_size, factor)
 }
 
-fn set_wpviewport_destination(wpviewport: &WpViewport, logical_size: Size<u32>) {
-    if logical_size.width != 0 && logical_size.height != 0 {
+fn set_wpviewport_destination(wpviewport: &WpViewport, window_size: Size<u32>) {
+    if window_size.width != 0 && window_size.height != 0 {
         // set_destination(0, 0) will panic
-        wpviewport.set_destination(logical_size.width as i32, logical_size.height as i32);
+        wpviewport.set_destination(window_size.width as i32, window_size.height as i32);
     }
 }

--- a/iced_layershell/src/conversion.rs
+++ b/iced_layershell/src/conversion.rs
@@ -10,15 +10,33 @@ use layershellev::keyboard::KeyLocation;
 use layershellev::keyboard::ModifiersState;
 use layershellev::xkb_keyboard::ElementState;
 use layershellev::xkb_keyboard::KeyEvent as LayerShellKeyEvent;
+use std::ops::Mul;
 
-pub fn window_event(layerevent: &LayerShellEvent, modifiers: ModifiersState) -> Option<IcedEvent> {
+fn scale_down<T>((x, y): (T, T), application_scale_factor: f64) -> (T, T)
+where
+    T: Mul + TryInto<f64> + TryFrom<f64>,
+    <T as TryInto<f64>>::Error: std::fmt::Debug,
+    <T as TryFrom<f64>>::Error: std::fmt::Debug,
+{
+    let (mut x, mut y): (f64, f64) = (x.try_into().unwrap(), y.try_into().unwrap());
+    x /= application_scale_factor;
+    y /= application_scale_factor;
+    (x.try_into().unwrap(), y.try_into().unwrap())
+}
+
+pub fn window_event(
+    layerevent: &LayerShellEvent,
+    application_scale_factor: f64,
+    modifiers: ModifiersState,
+) -> Option<IcedEvent> {
     match layerevent {
         LayerShellEvent::CursorLeft => Some(IcedEvent::Mouse(mouse::Event::CursorLeft)),
         LayerShellEvent::CursorMoved { x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Mouse(mouse::Event::CursorMoved {
                 position: iced_core::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
@@ -79,38 +97,42 @@ pub fn window_event(layerevent: &LayerShellEvent, modifiers: ModifiersState) -> 
             }
         })),
         LayerShellEvent::TouchDown { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerPressed {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
         LayerShellEvent::TouchUp { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerLifted {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
         LayerShellEvent::TouchMotion { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerMoved {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
         LayerShellEvent::TouchCancel { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerLost {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }

--- a/iced_layershell/src/multi_window/state.rs
+++ b/iced_layershell/src/multi_window/state.rs
@@ -16,6 +16,9 @@ where
     id: window::Id,
     application_scale_factor: f64,
     wayland_scale_factor: f64,
+    /// viewport_logical_size = window_size / application_scale_factor,
+    /// viewport_physical_size = window_size * wayland_scal_factor,
+    window_size: Size<u32>,
     viewport: Viewport,
     viewport_version: usize,
     theme: A::Theme,
@@ -40,18 +43,19 @@ where
         let theme = application.theme(id);
         let appearance = application.style(&theme, id);
 
-        let logical_size = Size::new(width, height);
-        let viewport = viewport(logical_size, wayland_scale_factor, application_scale_factor);
+        let window_size = Size::new(width, height);
+        let viewport = viewport(window_size, wayland_scale_factor, application_scale_factor);
 
         let wpviewport = window
             .viewport
             .clone()
             .expect("iced_layershell need viewport support to better wayland hidpi");
-        set_wpviewport_destination(&wpviewport, logical_size);
+        set_wpviewport_destination(&wpviewport, window_size);
         Self {
             id,
             application_scale_factor,
             wayland_scale_factor,
+            window_size,
             viewport,
             viewport_version: 0,
             theme,
@@ -66,28 +70,40 @@ where
     }
 
     pub fn update_view_port(&mut self, width: u32, height: u32, scale: f64) {
-        let logical_size = Size::new(width, height);
-        if self.logical_size_u32() == logical_size && self.wayland_scale_factor == scale {
+        let window_size = Size::new(width, height);
+        if self.window_size == window_size && self.wayland_scale_factor == scale {
             return;
         }
+        self.window_size = window_size;
         self.wayland_scale_factor = scale;
-        self.resize_viewport(logical_size);
+        self.resize_viewport();
+        set_wpviewport_destination(&self.wpviewport, self.window_size);
     }
 
     pub fn viewport(&self) -> &Viewport {
         &self.viewport
     }
 
-    pub fn physical_size(&self) -> Size<u32> {
-        self.viewport.physical_size()
+    pub fn window_size(&self) -> Size<u32> {
+        self.window_size
     }
 
-    pub fn logical_size(&self) -> Size<f32> {
-        self.viewport.logical_size()
+    /// using viewport physical size and wayland scale factor to calculate the actual window size.
+    /// The result may contain fractions.
+    pub fn window_size_f32(&self) -> Size<f32> {
+        let physical_size = self.viewport.physical_size();
+        Size::new(
+            (physical_size.width as f64 / self.wayland_scale_factor) as f32,
+            (physical_size.height as f64 / self.wayland_scale_factor) as f32,
+        )
     }
 
-    pub fn scale_factor(&self) -> f64 {
-        self.viewport.scale_factor()
+    pub fn wayland_scale_factor(&self) -> f64 {
+        self.wayland_scale_factor
+    }
+
+    pub fn application_scale_factor(&self) -> f64 {
+        self.application_scale_factor
     }
 
     pub fn text_color(&self) -> Color {
@@ -121,7 +137,10 @@ where
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
             | WindowEvent::TouchDown { x, y, .. } => {
-                self.mouse_position = Some(Point::new(*x as f32, *y as f32));
+                self.mouse_position = Some(Point::new(
+                    (*x / self.application_scale_factor) as f32,
+                    (*y / self.application_scale_factor) as f32,
+                ));
             }
             WindowEvent::ModifiersChanged(modifiers) => {
                 self.modifiers = *modifiers;
@@ -131,7 +150,7 @@ where
                 scale_u32: _,
             } => {
                 self.wayland_scale_factor = *scale_float;
-                self.resize_viewport(self.logical_size_u32());
+                self.resize_viewport();
             }
             _ => {}
         }
@@ -141,52 +160,53 @@ where
         let new_scale_factor = application.scale_factor(self.id);
         if self.application_scale_factor != new_scale_factor {
             self.application_scale_factor = new_scale_factor;
-            self.resize_viewport(self.logical_size_u32());
+            self.resize_viewport();
         }
         self.theme = application.theme(self.id);
         self.appearance = application.style(&self.theme, self.id);
     }
 
-    fn resize_viewport(&mut self, logical_size: Size<u32>) {
+    fn resize_viewport(&mut self) {
+        tracing::debug!(
+            "before resizing viewport, window_size: {:?}, viewport physical size: {:?}, viewport logical size: {:?}",
+            self.window_size,
+            self.viewport.physical_size(),
+            self.viewport.logical_size()
+        );
         self.viewport = viewport(
-            logical_size,
+            self.window_size,
             self.wayland_scale_factor,
             self.application_scale_factor,
         );
+        tracing::debug!(
+            "after resizing viewport, window_size: {:?}, viewport physical size: {:?}, viewport logical size: {:?}, wayland scale factor: {}, application scale factor: {}",
+            self.window_size,
+            self.viewport.physical_size(),
+            self.viewport.logical_size(),
+            self.wayland_scale_factor,
+            self.application_scale_factor
+        );
 
         self.viewport_version = self.viewport_version.wrapping_add(1);
-
-        set_wpviewport_destination(&self.wpviewport, self.logical_size_u32());
-    }
-
-    fn logical_size_u32(&self) -> Size<u32> {
-        // physical_size = (orig_logical_size as f64 * factor).ceil()
-        // logical_sizea = physical_size as f64 / factor as f32
-        // logical_size >= orig_logical_size
-        let logical_size = self.viewport.logical_size();
-        Size::new(
-            logical_size.width.floor() as u32,
-            logical_size.height.floor() as u32,
-        )
     }
 }
 
 fn viewport(
-    logical_size: Size<u32>,
+    window_size: Size<u32>,
     wayland_scale_factor: f64,
     application_scale_factor: f64,
 ) -> Viewport {
     let factor = wayland_scale_factor * application_scale_factor;
     let physical_size = Size::new(
-        (logical_size.width as f64 * factor).ceil() as u32,
-        (logical_size.height as f64 * factor).ceil() as u32,
+        (window_size.width as f64 * wayland_scale_factor).ceil() as u32,
+        (window_size.height as f64 * wayland_scale_factor).ceil() as u32,
     );
     Viewport::with_physical_size(physical_size, factor)
 }
 
-fn set_wpviewport_destination(wpviewport: &WpViewport, logical_size: Size<u32>) {
-    if logical_size.width != 0 && logical_size.height != 0 {
+fn set_wpviewport_destination(wpviewport: &WpViewport, window_size: Size<u32>) {
+    if window_size.width != 0 && window_size.height != 0 {
         // set_destination(0, 0) will panic
-        wpviewport.set_destination(logical_size.width as i32, logical_size.height as i32);
+        wpviewport.set_destination(window_size.width as i32, window_size.height as i32);
     }
 }

--- a/iced_layershell/src/multi_window/window_manager.rs
+++ b/iced_layershell/src/multi_window/window_manager.rs
@@ -81,7 +81,7 @@ where
     ) -> &mut Window<A, C> {
         let layerid = window.id();
         let state = State::new(id, application, size, fractal_scale, &window);
-        let physical_size = state.physical_size();
+        let physical_size = state.viewport().physical_size();
         let surface = compositor.create_surface(window, physical_size.width, physical_size.height);
         let renderer = compositor.create_renderer();
         let _ = self.aliases.insert(layerid, id);

--- a/iced_sessionlock/src/conversion.rs
+++ b/iced_sessionlock/src/conversion.rs
@@ -1,5 +1,7 @@
 mod keymap;
 
+use std::ops::Mul;
+
 use crate::event::IcedButtonState;
 use crate::event::WindowEvent as SessionLockEvent;
 use iced::touch;
@@ -12,14 +14,31 @@ use sessionlockev::xkb_keyboard::KeyEvent as SessionLockKeyEvent;
 use iced_core::{Event as IcedEvent, keyboard, mouse};
 use sessionlockev::keyboard::ModifiersState;
 
-pub fn window_event(layerevent: &SessionLockEvent, modifiers: ModifiersState) -> Option<IcedEvent> {
+fn scale_down<T>((x, y): (T, T), application_scale_factor: f64) -> (T, T)
+where
+    T: Mul + TryInto<f64> + TryFrom<f64>,
+    <T as TryInto<f64>>::Error: std::fmt::Debug,
+    <T as TryFrom<f64>>::Error: std::fmt::Debug,
+{
+    let (mut x, mut y): (f64, f64) = (x.try_into().unwrap(), y.try_into().unwrap());
+    x /= application_scale_factor;
+    y /= application_scale_factor;
+    (x.try_into().unwrap(), y.try_into().unwrap())
+}
+
+pub fn window_event(
+    layerevent: &SessionLockEvent,
+    application_scale_factor: f64,
+    modifiers: ModifiersState,
+) -> Option<IcedEvent> {
     match layerevent {
         SessionLockEvent::CursorLeft => Some(IcedEvent::Mouse(mouse::Event::CursorLeft)),
         SessionLockEvent::CursorMoved { x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Mouse(mouse::Event::CursorMoved {
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
@@ -38,38 +57,42 @@ pub fn window_event(layerevent: &SessionLockEvent, modifiers: ModifiersState) ->
             }))
         }
         SessionLockEvent::TouchDown { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerPressed {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
         SessionLockEvent::TouchUp { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerLifted {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
         SessionLockEvent::TouchMotion { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerMoved {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }
         SessionLockEvent::TouchCancel { id, x, y } => {
+            let (x, y) = scale_down((*x, *y), application_scale_factor);
             Some(IcedEvent::Touch(touch::Event::FingerLost {
                 id: touch::Finger(*id as u64),
                 position: iced::Point {
-                    x: *x as f32,
-                    y: *y as f32,
+                    x: x as f32,
+                    y: y as f32,
                 },
             }))
         }

--- a/iced_sessionlock/src/multi_window/state.rs
+++ b/iced_sessionlock/src/multi_window/state.rs
@@ -16,6 +16,9 @@ where
     id: window::Id,
     application_scale_factor: f64,
     wayland_scale_factor: f64,
+    /// viewport_logical_size = window_size / application_scale_factor,
+    /// viewport_physical_size = window_size * wayland_scal_factor,
+    window_size: Size<u32>,
     viewport: Viewport,
     viewport_version: usize,
     theme: A::Theme,
@@ -40,18 +43,19 @@ where
         let theme = application.theme();
         let appearance = application.style(&theme);
 
-        let logical_size = Size::new(width, height);
-        let viewport = viewport(logical_size, wayland_scale_factor, application_scale_factor);
+        let window_size = Size::new(width, height);
+        let viewport = viewport(window_size, wayland_scale_factor, application_scale_factor);
 
         let wpviewport = window
             .viewport
             .clone()
             .expect("iced_layershell need viewport support to better wayland hidpi");
-        set_wpviewport_destination(&wpviewport, logical_size);
+        set_wpviewport_destination(&wpviewport, window_size);
         Self {
             id,
             application_scale_factor,
             wayland_scale_factor,
+            window_size,
             viewport,
             viewport_version: 0,
             theme,
@@ -66,28 +70,40 @@ where
     }
 
     pub fn update_view_port(&mut self, width: u32, height: u32, scale: f64) {
-        let logical_size = Size::new(width, height);
-        if self.logical_size_u32() == logical_size && self.wayland_scale_factor == scale {
+        let window_size = Size::new(width, height);
+        if self.window_size == window_size && self.wayland_scale_factor == scale {
             return;
         }
+        self.window_size = window_size;
         self.wayland_scale_factor = scale;
-        self.resize_viewport(logical_size);
+        self.resize_viewport();
+        set_wpviewport_destination(&self.wpviewport, self.window_size);
     }
 
     pub fn viewport(&self) -> &Viewport {
         &self.viewport
     }
 
-    pub fn physical_size(&self) -> Size<u32> {
-        self.viewport.physical_size()
+    pub fn window_size(&self) -> Size<u32> {
+        self.window_size
     }
 
-    pub fn logical_size(&self) -> Size<f32> {
-        self.viewport.logical_size()
+    /// using viewport physical size and wayland scale factor to calculate the actual window size.
+    /// The result may contain fractions.
+    pub fn window_size_f32(&self) -> Size<f32> {
+        let physical_size = self.viewport.physical_size();
+        Size::new(
+            (physical_size.width as f64 / self.wayland_scale_factor) as f32,
+            (physical_size.height as f64 / self.wayland_scale_factor) as f32,
+        )
     }
 
-    pub fn scale_factor(&self) -> f64 {
-        self.viewport.scale_factor()
+    pub fn wayland_scale_factor(&self) -> f64 {
+        self.wayland_scale_factor
+    }
+
+    pub fn application_scale_factor(&self) -> f64 {
+        self.application_scale_factor
     }
 
     pub fn text_color(&self) -> Color {
@@ -117,7 +133,10 @@ where
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
             | WindowEvent::TouchDown { x, y, .. } => {
-                self.mouse_position = Some(Point::new(*x as f32, *y as f32));
+                self.mouse_position = Some(Point::new(
+                    (*x / self.application_scale_factor) as f32,
+                    (*y / self.application_scale_factor) as f32,
+                ));
             }
             WindowEvent::ModifiersChanged(modifiers) => {
                 self.modifiers = *modifiers;
@@ -127,7 +146,7 @@ where
                 scale_u32: _,
             } => {
                 self.wayland_scale_factor = *scale_float;
-                self.resize_viewport(self.logical_size_u32());
+                self.resize_viewport();
             }
             _ => {}
         }
@@ -137,52 +156,53 @@ where
         let new_scale_factor = application.scale_factor(self.id);
         if self.application_scale_factor != new_scale_factor {
             self.application_scale_factor = new_scale_factor;
-            self.resize_viewport(self.logical_size_u32());
+            self.resize_viewport();
         }
         self.theme = application.theme();
         self.appearance = application.style(&self.theme);
     }
 
-    fn resize_viewport(&mut self, logical_size: Size<u32>) {
+    fn resize_viewport(&mut self) {
+        tracing::debug!(
+            "before resizing viewport, window_size: {:?}, viewport physical size: {:?}, viewport logical size: {:?}",
+            self.window_size,
+            self.viewport.physical_size(),
+            self.viewport.logical_size()
+        );
         self.viewport = viewport(
-            logical_size,
+            self.window_size,
             self.wayland_scale_factor,
             self.application_scale_factor,
         );
+        tracing::debug!(
+            "after resizing viewport, window_size: {:?}, viewport physical size: {:?}, viewport logical size: {:?}, wayland scale factor: {}, application scale factor: {}",
+            self.window_size,
+            self.viewport.physical_size(),
+            self.viewport.logical_size(),
+            self.wayland_scale_factor,
+            self.application_scale_factor
+        );
 
         self.viewport_version = self.viewport_version.wrapping_add(1);
-
-        set_wpviewport_destination(&self.wpviewport, self.logical_size_u32());
-    }
-
-    fn logical_size_u32(&self) -> Size<u32> {
-        // physical_size = (orig_logical_size as f64 * factor).ceil()
-        // logical_sizea = physical_size as f64 / factor as f32
-        // logical_size >= orig_logical_size
-        let logical_size = self.viewport.logical_size();
-        Size::new(
-            logical_size.width.floor() as u32,
-            logical_size.height.floor() as u32,
-        )
     }
 }
 
 fn viewport(
-    logical_size: Size<u32>,
+    window_size: Size<u32>,
     wayland_scale_factor: f64,
     application_scale_factor: f64,
 ) -> Viewport {
     let factor = wayland_scale_factor * application_scale_factor;
     let physical_size = Size::new(
-        (logical_size.width as f64 * factor).ceil() as u32,
-        (logical_size.height as f64 * factor).ceil() as u32,
+        (window_size.width as f64 * wayland_scale_factor).ceil() as u32,
+        (window_size.height as f64 * wayland_scale_factor).ceil() as u32,
     );
     Viewport::with_physical_size(physical_size, factor)
 }
 
-fn set_wpviewport_destination(wpviewport: &WpViewport, logical_size: Size<u32>) {
-    if logical_size.width != 0 && logical_size.height != 0 {
+fn set_wpviewport_destination(wpviewport: &WpViewport, window_size: Size<u32>) {
+    if window_size.width != 0 && window_size.height != 0 {
         // set_destination(0, 0) will panic
-        wpviewport.set_destination(logical_size.width as i32, logical_size.height as i32);
+        wpviewport.set_destination(window_size.width as i32, window_size.height as i32);
     }
 }

--- a/iced_sessionlock/src/multi_window/window_manager.rs
+++ b/iced_sessionlock/src/multi_window/window_manager.rs
@@ -68,7 +68,7 @@ where
     ) -> &mut Window<A, C> {
         let layerid = window.id();
         let state = State::new(id, application, size, fractal_scale, &window);
-        let physical_size = state.physical_size();
+        let physical_size = state.viewport().physical_size();
         let surface = compositor.create_surface(window, physical_size.width, physical_size.height);
         let renderer = compositor.create_renderer();
         let _ = self.aliases.insert(layerid, id);


### PR DESCRIPTION
While I was copying the `multi_window` example from `iced` to this repo, I found that there is no effect on changing the application scale factor.

In this commit, a `window_size` is introduced in the window state. There are three  types of coordinates:
    1. `window_size`: The coordinates that the client believes it is using. These are used to communicate with the Wayland server.
    2. `viewport.physical_size`: The coordinates of the screen. These are used to render the final view that the user sees.
    3. `viewport.logical_size`: The coordinates used by Iced. Iced draws widgets based on these coordinates.

```
viewport.physical_size = window_size * wayland_scale_factor = viewport.logical_size * application_scale_factor * wayland_scale_factor
 ```

I also removed methods `physical_size` and `logical_size` from window state, because they are a bit confused. 