### PR TITLE
Feat/multitouch

### DIFF
--- a/iced_layershell/src/application/state.rs
+++ b/iced_layershell/src/application/state.rs
@@ -106,13 +106,14 @@ where
 
     pub fn update(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::CursorLeft | WindowEvent::TouchUp { .. } => {
+            WindowEvent::CursorLeft => {
                 self.mouse_position = None;
             }
             WindowEvent::CursorMoved { x, y }
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
-            | WindowEvent::TouchDown { x, y, .. } => {
+            | WindowEvent::TouchDown { x, y, .. }
+            | WindowEvent::TouchUp { x, y, .. } => {
                 self.mouse_position = Some(Point::new(
                     (*x / self.application_scale_factor) as f32,
                     (*y / self.application_scale_factor) as f32,

--- a/iced_layershell/src/multi_window/state.rs
+++ b/iced_layershell/src/multi_window/state.rs
@@ -130,13 +130,14 @@ where
 
     pub fn update(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::CursorLeft | WindowEvent::TouchUp { .. } => {
+            WindowEvent::CursorLeft => {
                 self.mouse_position = None;
             }
             WindowEvent::CursorMoved { x, y }
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
-            | WindowEvent::TouchDown { x, y, .. } => {
+            | WindowEvent::TouchDown { x, y, .. }
+            | WindowEvent::TouchUp { x, y, .. } => {
                 self.mouse_position = Some(Point::new(
                     (*x / self.application_scale_factor) as f32,
                     (*y / self.application_scale_factor) as f32,

--- a/iced_sessionlock/src/multi_window/state.rs
+++ b/iced_sessionlock/src/multi_window/state.rs
@@ -126,13 +126,14 @@ where
 
     pub fn update(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::CursorLeft | WindowEvent::TouchUp { .. } => {
+            WindowEvent::CursorLeft => {
                 self.mouse_position = None;
             }
             WindowEvent::CursorMoved { x, y }
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
-            | WindowEvent::TouchDown { x, y, .. } => {
+            | WindowEvent::TouchDown { x, y, .. }
+            | WindowEvent::TouchUp { x, y, .. } => {
                 self.mouse_position = Some(Point::new(
                     (*x / self.application_scale_factor) as f32,
                     (*y / self.application_scale_factor) as f32,

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -1581,7 +1581,7 @@ impl<T> Dispatch<wl_pointer::WlPointer, ()> for WindowState<T> {
                     WEnum::Value(ButtonState::Released) => {
                         state.pressed_mouse_buttons.remove(&button);
                     }
-                    _ => unreachable!("uknown wayland button state: {:?}", btnstate),
+                    _ => unreachable!("unknown wayland button state: {:?}", btnstate),
                 }
                 state.message.push((
                     state.surface_id(),

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -1084,13 +1084,11 @@ impl<T> WindowState<T> {
             } else {
                 None
             }
+        } else if self.pressed_mouse_buttons.is_empty() && self.finger_locations.is_empty() {
+            // no mouse button is pressed, and no touched
+            Some(surface.clone())
         } else {
-            if self.pressed_mouse_buttons.is_empty() && self.finger_locations.is_empty() {
-                // no mouse button is pressed, and no touched
-                Some(surface.clone())
-            } else {
-                None
-            }
+            None
         };
         if new_current_surface.is_none() || new_current_surface == self.current_surface {
             false

--- a/sessionlockev/src/lib.rs
+++ b/sessionlockev/src/lib.rs
@@ -1052,7 +1052,7 @@ impl<T> Dispatch<wl_pointer::WlPointer, ()> for WindowState<T> {
                     WEnum::Value(ButtonState::Released) => {
                         state.pressed_mouse_buttons.remove(&button);
                     }
-                    _ => unreachable!("uknown wayland button state: {:?}", btnstate),
+                    _ => unreachable!("unknown wayland button state: {:?}", btnstate),
                 }
                 state.message.push((
                     state.surface_id(),

--- a/sessionlockev/src/lib.rs
+++ b/sessionlockev/src/lib.rs
@@ -579,13 +579,11 @@ impl<T> WindowState<T> {
             } else {
                 None
             }
+        } else if self.pressed_mouse_buttons.is_empty() && self.finger_locations.is_empty() {
+            // no mouse button is pressed, and no touched
+            Some(surface.clone())
         } else {
-            if self.pressed_mouse_buttons.is_empty() && self.finger_locations.is_empty() {
-                // no mouse button is pressed, and no touched
-                Some(surface.clone())
-            } else {
-                None
-            }
+            None
         };
         if new_current_surface.is_none() || new_current_surface == self.current_surface {
             false


### PR DESCRIPTION
1. fix: inconsistent surface id between TouchDown event and TouchUp event in multi window.
2. fix: incorrect cursor position in TouchUp event.
3. feat: support multi touch.
4. feat: Dont't reset current_surface when TouchUp event and MouseLeave event happened. So keyboard events can still be sent to the last active surface instead of the first surface in the vector.