### PR TITLE
fixs of touch event within multi windows

### DIFF
--- a/iced_examples/multi_window/src/main.rs
+++ b/iced_examples/multi_window/src/main.rs
@@ -78,7 +78,7 @@ impl Example {
             7 => Anchor::Left | Anchor::Bottom,
             _ => Anchor::Bottom,
         };
-        let size = (1024, 768);
+        let size = (480, 320);
         let id = window::Id::unique();
         (
             id,

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -203,10 +203,8 @@ where
 
     let mut context = task::Context::from_waker(task::noop_waker_ref());
     let mut wl_input_region: Option<WlRegion> = None;
-    let mut pointer_serial: u32 = 0;
 
     let _ = ev.running_with_proxy(message_receiver, move |event, ev, _| {
-        use layershellev::DispatchMessage;
         let mut def_returndata = ReturnData::None;
         match event {
             LayerEvent::InitRequest => {
@@ -239,10 +237,6 @@ where
                 }
             }
             LayerEvent::RequestMessages(message) => {
-                if let DispatchMessage::MouseEnter { serial, .. } = message {
-                    pointer_serial = *serial;
-                }
-
                 event_sender
                     .start_send(message.into())
                     .expect("Cannot send");
@@ -329,7 +323,6 @@ where
                     ev.append_return_data(ReturnData::RequestSetCursorShape((
                         conversion::mouse_interaction(mouse),
                         pointer.clone(),
-                        pointer_serial,
                     )));
                 }
                 LayerShellAction::RedrawAll => {

--- a/iced_layershell/src/application/state.rs
+++ b/iced_layershell/src/application/state.rs
@@ -106,13 +106,14 @@ where
 
     pub fn update(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::CursorLeft | WindowEvent::TouchUp { .. } => {
+            WindowEvent::CursorLeft => {
                 self.mouse_position = None;
             }
             WindowEvent::CursorMoved { x, y }
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
-            | WindowEvent::TouchDown { x, y, .. } => {
+            | WindowEvent::TouchDown { x, y, .. }
+            | WindowEvent::TouchUp { x, y, .. } => {
                 self.mouse_position = Some(Point::new(
                     (*x / self.application_scale_factor) as f32,
                     (*y / self.application_scale_factor) as f32,

--- a/iced_layershell/src/event.rs
+++ b/iced_layershell/src/event.rs
@@ -104,6 +104,7 @@ pub enum IcedLayerEvent<Message: 'static> {
         fractal_scale: f64,
         wrapper: WindowWrapper,
         info: Option<iced_core::window::Id>,
+        is_mouse_surface: bool,
     },
     RequestRefresh {
         width: u32,

--- a/iced_layershell/src/multi_window/state.rs
+++ b/iced_layershell/src/multi_window/state.rs
@@ -130,13 +130,14 @@ where
 
     pub fn update(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::CursorLeft | WindowEvent::TouchUp { .. } => {
+            WindowEvent::CursorLeft => {
                 self.mouse_position = None;
             }
             WindowEvent::CursorMoved { x, y }
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
-            | WindowEvent::TouchDown { x, y, .. } => {
+            | WindowEvent::TouchDown { x, y, .. }
+            | WindowEvent::TouchUp { x, y, .. } => {
                 self.mouse_position = Some(Point::new(
                     (*x / self.application_scale_factor) as f32,
                     (*y / self.application_scale_factor) as f32,

--- a/iced_sessionlock/src/multi_window/state.rs
+++ b/iced_sessionlock/src/multi_window/state.rs
@@ -126,13 +126,14 @@ where
 
     pub fn update(&mut self, event: &WindowEvent) {
         match event {
-            WindowEvent::CursorLeft | WindowEvent::TouchUp { .. } => {
+            WindowEvent::CursorLeft => {
                 self.mouse_position = None;
             }
             WindowEvent::CursorMoved { x, y }
             | WindowEvent::CursorEnter { x, y }
             | WindowEvent::TouchMotion { x, y, .. }
-            | WindowEvent::TouchDown { x, y, .. } => {
+            | WindowEvent::TouchDown { x, y, .. }
+            | WindowEvent::TouchUp { x, y, .. } => {
                 self.mouse_position = Some(Point::new(
                     (*x / self.application_scale_factor) as f32,
                     (*y / self.application_scale_factor) as f32,

--- a/layershellev/README.md
+++ b/layershellev/README.md
@@ -78,11 +78,10 @@ fn main() {
             }
             LayerEvent::RequestMessages(DispatchMessage::MouseButton { .. }) => ReturnData::None,
             LayerEvent::RequestMessages(DispatchMessage::MouseEnter {
-                serial, pointer, ..
+                pointer, ..
             }) => ReturnData::RequestSetCursorShape((
                 "crosshair".to_owned(),
                 pointer.clone(),
-                *serial,
             )),
             LayerEvent::RequestMessages(DispatchMessage::MouseMotion {
                 time,

--- a/layershellev/examples/simplelayer.rs
+++ b/layershellev/examples/simplelayer.rs
@@ -73,13 +73,9 @@ fn main() {
                 ReturnData::None
             }
             LayerEvent::RequestMessages(DispatchMessage::MouseButton { .. }) => ReturnData::None,
-            LayerEvent::RequestMessages(DispatchMessage::MouseEnter {
-                serial, pointer, ..
-            }) => ReturnData::RequestSetCursorShape((
-                "crosshair".to_owned(),
-                pointer.clone(),
-                *serial,
-            )),
+            LayerEvent::RequestMessages(DispatchMessage::MouseEnter { pointer, .. }) => {
+                ReturnData::RequestSetCursorShape(("crosshair".to_owned(), pointer.clone()))
+            }
             LayerEvent::RequestMessages(DispatchMessage::MouseMotion {
                 time,
                 surface_x,

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -132,7 +132,7 @@ pub enum ReturnData<INFO> {
     RequestCompositor,
     RedrawAllRequest,
     RedrawIndexRequest(Id),
-    RequestSetCursorShape((String, WlPointer, u32)),
+    RequestSetCursorShape((String, WlPointer)),
     NewLayerShell((NewLayerShellSettings, id::Id, Option<INFO>)),
     NewPopUp((NewPopUpSettings, id::Id, Option<INFO>)),
     None,

--- a/sessionlockev/README.md
+++ b/sessionlockev/README.md
@@ -60,13 +60,11 @@ fn main() {
                 ReturnData::None
             }
             SessionLockEvent::RequestMessages(DispatchMessage::MouseEnter {
-                serial,
                 pointer,
                 ..
             }) => ReturnData::RequestSetCursorShape((
                 "crosshair".to_owned(),
                 pointer.clone(),
-                *serial,
             )),
             SessionLockEvent::RequestMessages(DispatchMessage::KeyBoard { key, .. }) => {
                 if *key == ESC_KEY {

--- a/sessionlockev/examples/simplelock.rs
+++ b/sessionlockev/examples/simplelock.rs
@@ -52,15 +52,9 @@ fn main() {
             SessionLockEvent::RequestMessages(DispatchMessage::MouseButton { .. }) => {
                 ReturnData::None
             }
-            SessionLockEvent::RequestMessages(DispatchMessage::MouseEnter {
-                serial,
-                pointer,
-                ..
-            }) => ReturnData::RequestSetCursorShape((
-                "crosshair".to_owned(),
-                pointer.clone(),
-                *serial,
-            )),
+            SessionLockEvent::RequestMessages(DispatchMessage::MouseEnter { pointer, .. }) => {
+                ReturnData::RequestSetCursorShape(("crosshair".to_owned(), pointer.clone()))
+            }
             SessionLockEvent::RequestMessages(DispatchMessage::KeyboardInput { event, .. }) => {
                 if let PhysicalKey::Code(KeyCode::Escape) = event.physical_key {
                     ReturnData::RequestUnlockAndExist

--- a/sessionlockev/src/events.rs
+++ b/sessionlockev/src/events.rs
@@ -77,7 +77,7 @@ pub enum ReturnData {
     RequestUnlockAndExist,
     RedrawAllRequest,
     RedrawIndexRequest(Id),
-    RequestSetCursorShape((String, WlPointer, u32)),
+    RequestSetCursorShape((String, WlPointer)),
     None,
 }
 /// Describes a scroll along one axis


### PR DESCRIPTION
This is a revision of #149 . In kwin6, I found touch events can be happened in different surfaces at the same time. So instead of updating `current_surface`, I store active surfaces in a map.

1. inconsistent surface of touch event.
2. incorrect position of touch event.
3. update `current_surface` only if a finger is down or a mouse button is clicked or a surface is created.
4. update cursor shape only if the surface is hovered by the mouse.
5. put the logic of setting cursor shape into a function.