### PR TITLE
Move iced features to separate feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = [
 ] }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"] }
 
-iced = { git = "https://github.com/iced-rs/iced.git" }
+iced = { git = "https://github.com/iced-rs/iced.git", features = ["auto-detect-theme"], default-features = false }
 iced_runtime = { git = "https://github.com/iced-rs/iced.git" }
 #iced_style = "0.13"
 iced_core = { git = "https://github.com/iced-rs/iced.git" }

--- a/iced_layershell/Cargo.toml
+++ b/iced_layershell/Cargo.toml
@@ -10,6 +10,12 @@ readme = "README.md"
 description = "layershell binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["tiny-skia", "wgpu", "fira-sans"]
+tiny-skia = ["iced/tiny-skia", "iced_renderer/tiny-skia"]
+wgpu = ["iced/wgpu", "iced_renderer/wgpu"]
+fira-sans = ["iced/fira-sans", "iced_renderer/fira-sans"]
+
 [dependencies]
 iced.workspace = true
 iced_renderer.workspace = true

--- a/iced_sessionlock/Cargo.toml
+++ b/iced_sessionlock/Cargo.toml
@@ -10,6 +10,12 @@ readme = "README.md"
 description = "sessionlock binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["tiny-skia", "wgpu", "fira-sans"]
+tiny-skia = ["iced/tiny-skia", "iced_renderer/tiny-skia"]
+wgpu = ["iced/wgpu", "iced_renderer/wgpu"]
+fira-sans = ["iced/fira-sans", "iced_renderer/fira-sans"]
+
 [dependencies]
 iced_sessionlock_macros.workspace = true
 


### PR DESCRIPTION
Hi,

This pull request disables the default features of the `iced` crate and moves them to separate feature flags for the `iced_layershell` and `iced_sessionlock` crates. 

The reason for this is simple: As soon as the `wgpu` feature flag is enabled, wgpu is used as the primary renderer and tiny-skia can only be used as a fallback renderer. One can use tiny-skia as primary renderer only when the `wgpu` feature flag is disabled and the `tiny-skia` feature flag is enabled. 

On my (hyprland) system, I noticed that wgpu does no damage tracking and re-renders the whole layer surface on every frame which results in a performance penalty. Additionally, tiny-skia has a much lower memory footprint which is also preferrable. 

With the changes of this pull request it's possible for users of this crate to disable the default features and only turn on the `tiny-skia` feature. This isn't possible with the current implementation. I've moved all default features of `iced` into the default features of this crate and therefore the default behavior should stay the same
