### PR TITLE
chore: bump xdg crate from 2.5.2 to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5488,9 +5488,9 @@ checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xkbcommon"

--- a/iced_examples/application_launcher/Cargo.toml
+++ b/iced_examples/application_launcher/Cargo.toml
@@ -24,5 +24,5 @@ iced_runtime.workspace = true
 iced_layershell.workspace = true
 gio = "0.20.5"
 regex = "1.11.1"
-xdg = "2.5.2"
+xdg = "3.0.0"
 tracing = "0.1.40"

--- a/iced_examples/application_launcher/src/applications.rs
+++ b/iced_examples/application_launcher/src/applications.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use gio::{AppLaunchContext, DesktopAppInfo};
 
 use gio::prelude::*;
-use iced::Pixels;
 use iced::widget::{button, column, image, row, svg, text};
+use iced::Pixels;
 use iced::{Element, Length};
 
 use crate::Message;
@@ -98,19 +98,17 @@ static ICONS_SIZE: &[&str] = &["256x256", "128x128"];
 static THEMES_LIST: &[&str] = &["breeze", "Adwaita"];
 
 fn get_icon_path_from_xdgicon(iconname: &str) -> Option<PathBuf> {
-    let scalable_icon_path =
-        xdg::BaseDirectories::with_prefix("icons/hicolor/scalable/apps").unwrap();
+    let scalable_icon_path = xdg::BaseDirectories::with_prefix("icons/hicolor/scalable/apps");
     if let Some(iconpath) = scalable_icon_path.find_data_file(format!("{iconname}.svg")) {
         return Some(iconpath);
     }
     for prefix in ICONS_SIZE {
-        let iconpath =
-            xdg::BaseDirectories::with_prefix(format!("icons/hicolor/{prefix}/apps")).unwrap();
+        let iconpath = xdg::BaseDirectories::with_prefix(format!("icons/hicolor/{prefix}/apps"));
         if let Some(iconpath) = iconpath.find_data_file(format!("{iconname}.png")) {
             return Some(iconpath);
         }
     }
-    let pixmappath = xdg::BaseDirectories::with_prefix("pixmaps").unwrap();
+    let pixmappath = xdg::BaseDirectories::with_prefix("pixmaps");
     if let Some(iconpath) = pixmappath.find_data_file(format!("{iconname}.svg")) {
         return Some(iconpath);
     }
@@ -118,13 +116,11 @@ fn get_icon_path_from_xdgicon(iconname: &str) -> Option<PathBuf> {
         return Some(iconpath);
     }
     for themes in THEMES_LIST {
-        let iconpath =
-            xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/48")).unwrap();
+        let iconpath = xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/48"));
         if let Some(iconpath) = iconpath.find_data_file(format!("{iconname}.svg")) {
             return Some(iconpath);
         }
-        let iconpath =
-            xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/64")).unwrap();
+        let iconpath = xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/64"));
         if let Some(iconpath) = iconpath.find_data_file(format!("{iconname}.svg")) {
             return Some(iconpath);
         }

--- a/iced_examples/bottom_panel/Cargo.toml
+++ b/iced_examples/bottom_panel/Cargo.toml
@@ -12,10 +12,10 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { workspace = true, features = ["image", "svg"] }
+iced = { workspace = true, features = ["tokio", "image", "svg"] }
 iced_runtime.workspace = true
 iced_layershell.workspace = true
 gio = "0.20.5"
 regex = "1.11.1"
-xdg = "2.5.2"
+xdg = "3.0.0"
 tracing = "0.1.40"

--- a/iced_examples/bottom_panel/src/applications.rs
+++ b/iced_examples/bottom_panel/src/applications.rs
@@ -83,19 +83,17 @@ static ICONS_SIZE: &[&str] = &["256x256", "256x256"];
 static THEMES_LIST: &[&str] = &["yaru"];
 
 fn get_icon_path_from_xdgicon(iconname: &str) -> Option<PathBuf> {
-    let scalable_icon_path =
-        xdg::BaseDirectories::with_prefix("icons/hicolor/scalable/apps").unwrap();
+    let scalable_icon_path = xdg::BaseDirectories::with_prefix("icons/hicolor/scalable/apps");
     if let Some(iconpath) = scalable_icon_path.find_data_file(format!("{iconname}.svg")) {
         return Some(iconpath);
     }
     for prefix in ICONS_SIZE {
-        let iconpath =
-            xdg::BaseDirectories::with_prefix(format!("icons/hicolor/{prefix}/apps")).unwrap();
+        let iconpath = xdg::BaseDirectories::with_prefix(format!("icons/hicolor/{prefix}/apps"));
         if let Some(iconpath) = iconpath.find_data_file(format!("{iconname}.png")) {
             return Some(iconpath);
         }
     }
-    let pixmappath = xdg::BaseDirectories::with_prefix("pixmaps").unwrap();
+    let pixmappath = xdg::BaseDirectories::with_prefix("pixmaps");
     if let Some(iconpath) = pixmappath.find_data_file(format!("{iconname}.svg")) {
         return Some(iconpath);
     }
@@ -103,13 +101,11 @@ fn get_icon_path_from_xdgicon(iconname: &str) -> Option<PathBuf> {
         return Some(iconpath);
     }
     for themes in THEMES_LIST {
-        let iconpath =
-            xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/48")).unwrap();
+        let iconpath = xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/48"));
         if let Some(iconpath) = iconpath.find_data_file(format!("{iconname}.svg")) {
             return Some(iconpath);
         }
-        let iconpath =
-            xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/64")).unwrap();
+        let iconpath = xdg::BaseDirectories::with_prefix(format!("icons/{themes}/apps/64"));
         if let Some(iconpath) = iconpath.find_data_file(format!("{iconname}.svg")) {
             return Some(iconpath);
         }


### PR DESCRIPTION
### Changes made:
- Removed `unwrap()` on `xdg::BaseDirectories::with_prefix()` function calls
- Added tokio executor for iced in `bottom_panel` example