### PR TITLE
feat(layershell): support zwp_input_panel_v1

### DIFF
--- a/iced_layershell/src/actions.rs
+++ b/iced_layershell/src/actions.rs
@@ -4,8 +4,8 @@ use enumflags2::BitFlags;
 use iced::window::Id as IcedId;
 use iced_core::input_method;
 use iced_core::mouse::Interaction;
-use layershellev::NewLayerShellSettings;
 use layershellev::id::Id as LayerId;
+use layershellev::{NewInputPanelSettings, NewLayerShellSettings};
 
 use std::sync::Arc;
 
@@ -88,6 +88,10 @@ pub enum LayershellCustomActions {
     },
     NewMenu {
         settings: IcedNewMenuSettings,
+        id: IcedId,
+    },
+    NewInputPanel {
+        settings: NewInputPanelSettings,
         id: IcedId,
     },
     /// is same with WindowAction::Close(id)

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -14,6 +14,7 @@ pub mod settings;
 pub mod reexport {
     pub use layershellev::NewInputPanelSettings;
     pub use layershellev::NewLayerShellSettings;
+    pub use layershellev::WithConnection;
     pub use layershellev::reexport::Anchor;
     pub use layershellev::reexport::KeyboardInteractivity;
     pub use layershellev::reexport::Layer;

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -12,6 +12,7 @@ mod proxy;
 pub mod settings;
 
 pub mod reexport {
+    pub use layershellev::NewInputPanelSettings;
     pub use layershellev::NewLayerShellSettings;
     pub use layershellev::reexport::Anchor;
     pub use layershellev::reexport::KeyboardInteractivity;

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -97,6 +97,7 @@ where
             .with_exclusive_zone(settings.layer_settings.exclusive_zone)
             .with_margin(settings.layer_settings.margin)
             .with_keyboard_interacivity(settings.layer_settings.keyboard_interactivity)
+            .with_connection(settings.with_connection)
             .build()
             .expect("Cannot create layershell");
 

--- a/iced_layershell/src/settings.rs
+++ b/iced_layershell/src/settings.rs
@@ -6,7 +6,7 @@ use crate::reexport::{Anchor, KeyboardInteractivity, Layer};
 
 pub use layershellev::StartMode;
 
-use layershellev::reexport::wayland_client::wl_keyboard::KeymapFormat;
+use layershellev::{WithConnection, reexport::wayland_client::wl_keyboard::KeymapFormat};
 
 #[derive(Debug)]
 pub struct VirtualKeyboardSettings {
@@ -52,6 +52,8 @@ pub struct Settings {
     pub antialiasing: bool,
 
     pub virtual_keyboard_support: Option<VirtualKeyboardSettings>,
+
+    pub with_connection: Option<WithConnection>,
 }
 impl Default for Settings {
     fn default() -> Self {
@@ -63,6 +65,7 @@ impl Default for Settings {
             default_text_size: Pixels(16.0),
             antialiasing: false,
             virtual_keyboard_support: None,
+            with_connection: None,
         }
     }
 }

--- a/iced_layershell_macros/src/lib.rs
+++ b/iced_layershell_macros/src/lib.rs
@@ -51,6 +51,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                 NewLayerShell { settings: iced_layershell::reexport::NewLayerShellSettings, id: iced::window::Id },
                 NewPopUp { settings: iced_layershell::actions::IcedNewPopupSettings, id: iced::window::Id },
                 NewMenu { settings: iced_layershell::actions::IcedNewMenuSettings, id: iced::window::Id },
+                NewInputPanel { settings: iced_layershell::reexport::NewInputPanelSettings, id: iced::window::Id },
                 RemoveWindow(iced::window::Id),
                 ForgetLastOutput,
             };
@@ -77,6 +78,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                             Self::NewLayerShell {settings, id } => Ok(LayershellCustomActionsWithId::new(None, LayershellCustomActions::NewLayerShell { settings, id })),
                             Self::NewPopUp { settings, id } => Ok(LayershellCustomActionsWithId::new(None, LayershellCustomActions::NewPopUp { settings, id })),
                             Self::NewMenu { settings, id } =>  Ok(LayershellCustomActionsWithId::new(None, LayershellCustomActions::NewMenu {settings, id })),
+                            Self::NewInputPanel {settings, id } => Ok(LayershellCustomActionsWithId::new(None, LayershellCustomActions::NewInputPanel { settings, id })),
                             Self::RemoveWindow(id) => Ok(LayershellCustomActionsWithId::new(None, LayershellCustomActions::RemoveWindow(id))),
                             Self::ForgetLastOutput => Ok(LayershellCustomActionsWithId::new(None, LayershellCustomActions::ForgetLastOutput)),
                             _ => Err(self)

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -96,6 +96,18 @@ pub struct NewPopUpSettings {
     pub id: id::Id,
 }
 
+/// input panel settings to create a new input panel surface
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NewInputPanelSettings {
+    pub size: (u32, u32),
+    /// set the surface type as a keyboard
+    pub keyboard: bool,
+    /// follow the last output of the activated surface, used to create some thing like mako, who
+    /// will show on the same window, only when the notifications is cleared, it will change the
+    /// wl_output.
+    pub use_last_output: bool,
+}
+
 impl Default for NewLayerShellSettings {
     fn default() -> Self {
         NewLayerShellSettings {
@@ -135,6 +147,7 @@ pub enum ReturnData<INFO> {
     RequestSetCursorShape((String, WlPointer)),
     NewLayerShell((NewLayerShellSettings, id::Id, Option<INFO>)),
     NewPopUp((NewPopUpSettings, id::Id, Option<INFO>)),
+    NewInputPanel((NewInputPanelSettings, id::Id, Option<INFO>)),
     None,
 }
 


### PR DESCRIPTION
1. support zwp_input_panel_v1.
2. add `with_connection` in `Settings` so that an application can extend their wayland implementation.

## Background of Adding `with_connection`
In kwin, only the connection opened from `WAYLAND_SOCKET` can use `zwp_input_panel_v1` and `zwp_input_method_v1`. So if we want to show a input panel and input something through this input panel, we must implement `zwp_input_panel_v1` and `zwp_input_method_v1` in the same program. With `with_connection`, an application can create a connection and register its wayland event queue.