### PR TITLE
feat: handle layer shell surface close event.

### DIFF
--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -175,7 +175,7 @@ where
             LayerEvent::WindowClosed => {
                 event_sender
                     // there is only one window, id doesn't matter.
-                    .start_send(IcedLayerEvent::WindowRemoved(IcedCoreWindow::Id::unique()))
+                    .start_send(IcedLayerEvent::WindowRemoved(main_id))
                     .expect("Cannot send");
             }
             _ => {}

--- a/iced_layershell/src/application.rs
+++ b/iced_layershell/src/application.rs
@@ -172,6 +172,12 @@ where
                     .start_send(IcedLayerEvent::UserEvent(event))
                     .ok();
             }
+            LayerEvent::WindowClosed => {
+                event_sender
+                    // there is only one window, id doesn't matter.
+                    .start_send(IcedLayerEvent::WindowRemoved(IcedCoreWindow::Id::unique()))
+                    .expect("Cannot send");
+            }
             _ => {}
         }
         let poll = instance.as_mut().poll(&mut context);
@@ -657,6 +663,9 @@ async fn run_instance<A, E, C>(
                         main_id,
                     ));
                 }
+            }
+            IcedLayerEvent::WindowRemoved(_) => {
+                should_exit = true;
             }
             _ => unreachable!(),
         }

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -223,6 +223,19 @@ where
                     ))
                     .expect("Cannot send");
             }
+            LayerEvent::WindowClosed => {
+                let Some(unit) = sended_id.and_then(|unit_id| ev.get_mut_unit_with_id(unit_id)) else {
+                    return def_returndata;
+                };
+                if let Some(id) = unit.get_binding() {
+                    event_sender
+                        .start_send(MultiWindowIcedLayerEvent(
+                                sended_id,
+                                IcedLayerEvent::WindowRemoved(*id),
+                        ))
+                        .expect("Cannot send");
+                }
+            }
             _ => {}
         }
         let poll = instance.as_mut().poll(&mut context);

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -66,6 +66,8 @@ pub enum LayerEvent<'a, T, Message> {
     NormalDispatch,
     /// It return the event you passed with message_receiver, and return it back.
     UserEvent(Message),
+    /// Window is closed by the wayland server.
+    WindowClosed,
 }
 
 /// layershell settings to create a new layershell surface
@@ -298,6 +300,8 @@ pub(crate) enum DispatchMessageInner {
     },
     XdgInfoChanged(XdgInfoChangedType),
     Ime(Ime),
+    /// Window is closed by the wayland server.
+    WindowClosed,
 }
 
 /// This tell the DispatchMessage by dispatch
@@ -511,6 +515,9 @@ impl From<DispatchMessageInner> for DispatchMessage {
             DispatchMessageInner::Ime(ime) => DispatchMessage::Ime(ime),
             DispatchMessageInner::RefreshSurface { .. } => unimplemented!(),
             DispatchMessageInner::XdgInfoChanged(_) => unimplemented!(),
+            DispatchMessageInner::WindowClosed => {
+                unreachable!("WindowClosed won't be dispatched by DispatchMessage")
+            }
         }
     }
 }


### PR DESCRIPTION
In kwin, if the geometry of the surface is invalid, kwin will close the window. We should handle the close event from wayland server to work correctly. Currently, the main loop will freeze. Possibly it freezes in calling compositor.present (I haven't debugged this case).