### PR TITLE
Move theme detection behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,7 @@ rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = [
 ] }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"] }
 
-iced = { git = "https://github.com/iced-rs/iced.git", features = [
-  "auto-detect-theme",
-], default-features = false }
+iced = { git = "https://github.com/iced-rs/iced.git", default-features = false }
 iced_runtime = { git = "https://github.com/iced-rs/iced.git" }
 #iced_style = "0.13"
 iced_core = { git = "https://github.com/iced-rs/iced.git" }

--- a/iced_layershell/Cargo.toml
+++ b/iced_layershell/Cargo.toml
@@ -11,13 +11,14 @@ description = "layershell binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tiny-skia", "wgpu", "fira-sans"]
+default = ["tiny-skia", "wgpu", "fira-sans", "auto-detect-theme"]
 tiny-skia = ["iced/tiny-skia", "iced_renderer/tiny-skia"]
 wgpu = ["iced/wgpu", "iced_renderer/wgpu"]
 fira-sans = ["iced/fira-sans", "iced_renderer/fira-sans"]
 debug = ["iced/debug"]
 time-travel = ["iced/time-travel"]
 unconditional-rendering = ["iced/unconditional-rendering"]
+auto-detect-theme = ["iced/auto-detect-theme"]
 
 [dependencies]
 iced.workspace = true

--- a/iced_sessionlock/Cargo.toml
+++ b/iced_sessionlock/Cargo.toml
@@ -11,13 +11,14 @@ description = "sessionlock binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tiny-skia", "wgpu", "fira-sans"]
+default = ["tiny-skia", "wgpu", "fira-sans", "auto-detect-theme"]
 tiny-skia = ["iced/tiny-skia", "iced_renderer/tiny-skia"]
 wgpu = ["iced/wgpu", "iced_renderer/wgpu"]
 fira-sans = ["iced/fira-sans", "iced_renderer/fira-sans"]
 debug = ["iced/debug"]
 time-travel = ["iced/time-travel"]
 unconditional-rendering = ["iced/unconditional-rendering"]
+auto-detect-theme = ["iced/auto-detect-theme"]
 
 [dependencies]
 iced_sessionlock_macros.workspace = true


### PR DESCRIPTION
Hi,

In #154 I intentionally left the `auto-detect-theme` feature flag as a iced default. However, I just realized that this depends on zbus and therefore on an async runtime. Since their default async runtime is `async-std` this will add a new, additional runtime for most projects. 

Therefore, I think it's better to be able to turn this off as it may cause a lot of hardware threads to be allocated for a feature which isn't needed (as it's the case for me)