### PR TITLE
Run `Action::Widget` on all windows

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -1043,23 +1043,20 @@ pub(crate) fn run_action<P, C>(
         Action::Widget(action) => {
             let mut current_operation = Some(action);
 
-            'operate: while let Some(mut operation) = current_operation.take() {
+            while let Some(mut operation) = current_operation.take() {
+                // kind of suboptimal that we have to iterate over all windows, but since an operation does not have
+                // a window id associated with it, this is the best we can do for now
                 for (id, window) in window_manager.iter_mut() {
                     if let Some(mut ui) = user_interfaces.ui_mut(&id) {
                         ui.operate(&window.renderer, operation.as_mut());
+                    }
+                }
 
-                        match operation.finish() {
-                            operation::Outcome::None => {}
-                            operation::Outcome::Some(_message) => {
-                                //proxy.send_event(message).ok();
-
-                                // operation completed, don't need to try to operate on rest of UIs
-                                break 'operate;
-                            }
-                            operation::Outcome::Chain(next) => {
-                                current_operation = Some(next);
-                            }
-                        }
+                match operation.finish() {
+                    operation::Outcome::None => {}
+                    operation::Outcome::Some(()) => {}
+                    operation::Outcome::Chain(next) => {
+                        current_operation = Some(next);
                     }
                 }
             }

--- a/iced_sessionlock/src/multi_window.rs
+++ b/iced_sessionlock/src/multi_window.rs
@@ -727,23 +727,20 @@ pub(crate) fn run_action<P, C>(
         Action::Widget(action) => {
             let mut current_operation = Some(action);
 
-            'operate: while let Some(mut operation) = current_operation.take() {
+            while let Some(mut operation) = current_operation.take() {
+                // kind of suboptimal that we have to iterate over all windows, but since an operation does not have
+                // a window id associated with it, this is the best we can do for now
                 for (id, window) in window_manager.iter_mut() {
                     if let Some(mut ui) = user_interfaces.ui_mut(&id) {
                         ui.operate(&window.renderer, operation.as_mut());
+                    }
+                }
 
-                        match operation.finish() {
-                            operation::Outcome::None => {}
-                            operation::Outcome::Some(_message) => {
-                                //proxy.send_event(message).ok();
-
-                                // operation completed, don't need to try to operate on rest of UIs
-                                break 'operate;
-                            }
-                            operation::Outcome::Chain(next) => {
-                                current_operation = Some(next);
-                            }
-                        }
+                match operation.finish() {
+                    operation::Outcome::None => {}
+                    operation::Outcome::Some(()) => {}
+                    operation::Outcome::Chain(next) => {
+                        current_operation = Some(next);
                     }
                 }
             }


### PR DESCRIPTION
This pull request adjusts the functionality of `Action::Widget` to be like in upstream iced: 

https://github.com/iced-rs/iced/blob/283d0e74a8050ea625da25e0b9180b65f11d1843/winit/src/lib.rs#L1422-L1440

The old functionality wrongly assumed that the action needs to be run on the first window returned by the iterator. This assumption is wrong if there are multiple windows. The new functionality is not optimal for performance, however upstream iced uses the same so idk how bad it is

closes #217 