### PR TITLE
Commit input region changes

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -687,6 +687,7 @@ where
                 layer_shell_window
                     .get_wlsurface()
                     .set_input_region(self.wl_input_region.as_ref());
+                layer_shell_window.get_wlsurface().commit();
             }
             LayershellCustomAction::VirtualKeyboardPressed { time, key } => {
                 use layershellev::reexport::wayland_client::KeyState;


### PR DESCRIPTION
Instantaneously send a `wl_surface.commit` after a change to the input region of a surface has been done. 

closes #219 