### PR TITLE
Handle size for LayerShellSettings & fix for TargetScreen

### DIFF
--- a/iced_layershell/src/build_pattern/daemon.rs
+++ b/iced_layershell/src/build_pattern/daemon.rs
@@ -612,6 +612,12 @@ impl<P: Program> Daemon<P> {
                 None
             },
         };
+        use layershellev::StartMode;
+        assert!(
+            settings.layer_settings.size.is_some()
+                || matches!(settings.layer_settings.start_mode, StartMode::Background),
+            "Size must be specified unless start_mode is Background"
+        );
         crate::multi_window::run(program, &self.namespace, settings, renderer_settings)
     }
 

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -2608,7 +2608,7 @@ impl<T: 'static> WindowState<T> {
                 .viewport(viewport)
                 .zxdgoutput(binded_xdginfo)
                 .fractional_scale(fractional_scale)
-                .wl_output(binded_output.clone()) 
+                .wl_output(binded_output.clone())
                 .build(),
             );
         } else {

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -2608,6 +2608,7 @@ impl<T: 'static> WindowState<T> {
                 .viewport(viewport)
                 .zxdgoutput(binded_xdginfo)
                 .fractional_scale(fractional_scale)
+                .wl_output(binded_output.clone()) 
                 .build(),
             );
         } else {


### PR DESCRIPTION
First commit fixes TargetScreen option, as without it TargetScreen is broken and doesn't work
Second commit fixes #221. Not a fallback, but proper error.
