### PR TITLE
Run `mundy` inside `Runtime` context like in `iced_winit`

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -135,12 +135,15 @@ where
                 .boxed(),
         );
 
-        mundy::Preferences::once_blocking(
-            mundy::Interest::ColorScheme,
-            core::time::Duration::from_millis(200),
-        )
-        .map(|preferences| to_mode(preferences.color_scheme))
-        .unwrap_or_default()
+        runtime
+            .enter(|| {
+                mundy::Preferences::once_blocking(
+                    mundy::Interest::ColorScheme,
+                    core::time::Duration::from_millis(200),
+                )
+            })
+            .map(|preferences| to_mode(preferences.color_scheme))
+            .unwrap_or_default()
     };
 
     let context = Context::<


### PR DESCRIPTION
Just like in `iced_winit`: https://github.com/iced-rs/iced/commit/0b78f2aa5d0a741da79f3b2b0a91046c32587403.

Without this, mundy panics when using zbus with tokio because it lacks a runtime.