### PR TITLE
fix iced_layershell missing field

### DIFF
--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -944,6 +944,7 @@ where
                 redraw_request,
                 input_method,
                 mouse_interaction,
+                has_layout_changed: _,
             } => {
                 if unconditional_rendering {
                     ev.request_refresh(window.id, RefreshRequest::NextFrame);


### PR DESCRIPTION
fix for an error introduced in #288 

```
error[E0027]: pattern does not mention field `has_layout_changed`
   --> exwlshelleventloop/iced_layershell/src/multi_window.rs:943:13
    |
943 | /             user_interface::State::Updated {
944 | |                 redraw_request,
945 | |                 input_method,
946 | |                 mouse_interaction,
947 | |                 // has_layout_changed,
948 | |             } => {
    | |_____________^ missing field `has_layout_changed`
    |
help: include the missing field in the pattern
    |
946 -                 mouse_interaction,
947 -                 // has_layout_changed,
948 -             } => {
946 +                 mouse_interaction, has_layout_changed } => {
    |
help: if you don't care about this missing field, you can explicitly ignore it
    |
946 -                 mouse_interaction,
947 -                 // has_layout_changed,
948 -             } => {
946 +                 mouse_interaction, has_layout_changed: _ } => {
    |
help: or always ignore missing fields here
    |
946 -                 mouse_interaction,
947 -                 // has_layout_changed,
948 -             } => {
946 +                 mouse_interaction, .. } => {
    |
```