### PR TITLE
Move linux-theme-detection behind feature gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "iced_debug",
  "iced_program",
  "log",
+ "mundy",
  "rustc-hash 2.1.1",
  "thiserror 2.0.17",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ wayland-protocols = { version = "0.32.5", default-features = false, features = [
   "client",
 ] }
 
-mundy = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["std", "env-filter"] }
 
 wayland-cursor = "0.31.7"

--- a/iced_layershell/Cargo.toml
+++ b/iced_layershell/Cargo.toml
@@ -11,13 +11,14 @@ description = "layershell binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tiny-skia", "wgpu", "fira-sans"]
+default = ["tiny-skia", "wgpu", "fira-sans", "linux-theme-detection"]
 tiny-skia = ["iced/tiny-skia", "iced_renderer/tiny-skia"]
 wgpu = ["iced/wgpu", "iced_renderer/wgpu"]
 fira-sans = ["iced/fira-sans", "iced_renderer/fira-sans"]
 debug = ["iced/debug"]
 time-travel = ["iced/time-travel"]
 unconditional-rendering = ["iced/unconditional-rendering"]
+linux-theme-detection = ["iced/linux-theme-detection", "dep:mundy"]
 
 [dependencies]
 iced.workspace = true
@@ -38,4 +39,7 @@ window_clipboard.workspace = true
 log.workspace = true
 futures.workspace = true
 enumflags2.workspace = true
-mundy.workspace = true
+
+# workspace features cannot be optional so we need to define the dependency here
+mundy = { version = "0.2.0", optional = true }
+

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -21,6 +21,8 @@ use crate::{
     actions::LayershellCustomAction, clipboard::LayerShellClipboard, conversion, error::Error,
 };
 
+#[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
+use iced::theme::Mode;
 use iced::{
     Event as IcedEvent, theme,
     window::{Event as IcedWindowEvent, Id as IcedId, RedrawRequest},
@@ -118,6 +120,7 @@ where
         .build()
         .expect("Cannot create layershell");
 
+    #[cfg(all(feature = "linux-theme-detection", target_os = "linux"))]
     let system_theme = {
         let to_mode = |color_scheme| match color_scheme {
             mundy::ColorScheme::NoPreference => theme::Mode::None,
@@ -145,6 +148,9 @@ where
             .map(|preferences| to_mode(preferences.color_scheme))
             .unwrap_or_default()
     };
+
+    #[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
+    let system_theme = Mode::default();
 
     let context = Context::<
         P,

--- a/iced_sessionlock/Cargo.toml
+++ b/iced_sessionlock/Cargo.toml
@@ -11,13 +11,14 @@ description = "sessionlock binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tiny-skia", "wgpu", "fira-sans"]
+default = ["tiny-skia", "wgpu", "fira-sans", "linux-theme-detection"]
 tiny-skia = ["iced/tiny-skia", "iced_renderer/tiny-skia"]
 wgpu = ["iced/wgpu", "iced_renderer/wgpu"]
 fira-sans = ["iced/fira-sans", "iced_renderer/fira-sans"]
 debug = ["iced/debug"]
 time-travel = ["iced/time-travel"]
 unconditional-rendering = ["iced/unconditional-rendering"]
+linux-theme-detection = ["iced/linux-theme-detection", "dep:mundy"]
 
 [dependencies]
 iced_sessionlock_macros.workspace = true
@@ -36,4 +37,6 @@ sessionlockev.workspace = true
 futures.workspace = true
 window_clipboard.workspace = true
 log.workspace = true
-mundy.workspace = true
+
+# workspace features cannot be optional so we need to define the dependency here
+mundy = { version = "0.2.0", optional = true }

--- a/iced_sessionlock/src/multi_window.rs
+++ b/iced_sessionlock/src/multi_window.rs
@@ -13,6 +13,8 @@ use std::{
 use crate::{clipboard::SessionLockClipboard, conversion, error::Error};
 
 use super::DefaultStyle;
+#[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
+use iced::theme::Mode;
 use iced_graphics::{Compositor, compositor};
 
 use iced_core::{Size, time::Instant};
@@ -83,6 +85,7 @@ where
     runtime.track(iced_futures::subscription::into_recipes(
         runtime.enter(|| application.subscription().map(Action::Output)),
     ));
+    #[cfg(all(feature = "linux-theme-detection", target_os = "linux"))]
     let system_theme = {
         let to_mode = |color_scheme| match color_scheme {
             mundy::ColorScheme::NoPreference => theme::Mode::None,
@@ -110,6 +113,9 @@ where
             .map(|preferences| to_mode(preferences.color_scheme))
             .unwrap_or_default()
     };
+
+    #[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
+    let system_theme = Mode::default();
 
     let ev: WindowState<()> = sessionlockev::WindowState::new()
         .with_use_display_handle(true)


### PR DESCRIPTION
Hi,

This pull request moves the mundy-logic behind the `linux-theme-detection` feature gate as upstream iced does it. 

I need to get rid of mundy since it's `zbus` dependency causes a compile error on my project.