### PR TITLE
perf: replace idle roundtrip() with dispatch_pending() + flush()

### DIFF
--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -3518,13 +3518,21 @@ impl<T: 'static> WindowState<T> {
 
             let r_window_state = &mut state;
             let window_state = &mut r_window_state.raw;
-            // Process events already buffered by the calloop WaylandSource
-            // without sending wl_display.sync.  roundtrip() generates a
-            // sync→done pair every iteration (~48 Hz feedback loop even when
-            // idle).  dispatch_pending() + flush() is sufficient because the
-            // WaylandSource reads from the Wayland socket and routes events
-            // to all queues; we just need to dispatch what was buffered for
-            // event_queue_origin and flush any outgoing requests.
+            // Use dispatch_pending() + flush() instead of roundtrip().
+            //
+            // roundtrip() sends wl_display.sync every call, blocking until
+            // the compositor replies — creating a ~48 Hz feedback loop even
+            // when idle.  Its docs note it is meant for "initial setup" and
+            // one-off synchronisation points, not per-frame use:
+            // https://docs.rs/wayland-client/latest/wayland_client/struct.EventQueue.html#method.roundtrip
+            //
+            // dispatch_pending() processes events already buffered by the
+            // calloop WaylandSource (which reads the Wayland socket and
+            // routes events to all queues), without any I/O:
+            // https://docs.rs/wayland-client/latest/wayland_client/struct.EventQueue.html#method.dispatch_pending
+            //
+            // flush() sends any outgoing requests queued by event handlers:
+            // https://docs.rs/wayland-client/latest/wayland_client/struct.EventQueue.html#method.flush
             let _ = event_queue_origin.dispatch_pending(window_state);
             let _ = connection.flush();
             let event_handler = &mut r_window_state.fun;

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -3518,7 +3518,15 @@ impl<T: 'static> WindowState<T> {
 
             let r_window_state = &mut state;
             let window_state = &mut r_window_state.raw;
-            let _ = event_queue_origin.roundtrip(window_state);
+            // Process events already buffered by the calloop WaylandSource
+            // without sending wl_display.sync.  roundtrip() generates a
+            // sync→done pair every iteration (~48 Hz feedback loop even when
+            // idle).  dispatch_pending() + flush() is sufficient because the
+            // WaylandSource reads from the Wayland socket and routes events
+            // to all queues; we just need to dispatch what was buffered for
+            // event_queue_origin and flush any outgoing requests.
+            let _ = event_queue_origin.dispatch_pending(window_state);
+            let _ = connection.flush();
             let event_handler = &mut r_window_state.fun;
             if process_window_state(window_state, event_handler) {
                 break;

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -3534,7 +3534,6 @@ impl<T: 'static> WindowState<T> {
             // flush() sends any outgoing requests queued by event handlers:
             // https://docs.rs/wayland-client/latest/wayland_client/struct.EventQueue.html#method.flush
             let _ = event_queue_origin.dispatch_pending(window_state);
-            let _ = connection.flush();
             let event_handler = &mut r_window_state.fun;
             if process_window_state(window_state, event_handler) {
                 break;
@@ -3604,6 +3603,10 @@ impl<T: 'static> WindowState<T> {
                     })
                     .ok();
             }
+            // Flush after all event handlers have run so outgoing requests
+            // (e.g. wl_surface.commit from process_window_state) reach the
+            // compositor before the next dispatch() potentially sleeps.
+            let _ = connection.flush();
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Builds on #364. `event_queue_origin.roundtrip()` sends `wl_display.sync` on every loop iteration. The compositor responds with `wl_callback.done`, which wakes the calloop `WaylandSource`, creating a ~48 Hz feedback loop even when fully idle.

This replaces it with:
- `event_queue_origin.dispatch_pending()` — process already-buffered events without I/O
- `connection.flush()` — send any queued outgoing requests

The calloop `WaylandSource` already reads from the Wayland socket and routes events to all queues, so the explicit roundtrip synchronization is redundant for normal operation.

## Impact

Combined with #364, reduces idle CPU from ~0.7% to 0.0% (6 total syscalls over 10 seconds, measured with `strace -c` and `perf stat` on Hyprland).

## Risk

This changes the event processing model — events on `event_queue_origin` are now dispatched only when the `WaylandSource` has already read them, rather than being synchronously pulled via `roundtrip()`. This needs testing on compositors beyond Hyprland (Sway, cosmic-comp, etc.) to verify no edge cases break.

Only `layershellev` is patched here — `exwlshellev` and `sessionlockev` have the same pattern.

## Disclaimer

This was generated with the help of Claude Code. I've verified it reduces idle CPU on my machine and am currently using it, but there hasn't been a human code review beyond that. I have minimal Rust knowledge. Feel free to close this without looking at it if you'd rather approach the fix differently.

Relates to #159