### PR TITLE
feat: add clipboard opt-out at init

### DIFF
--- a/iced_exwlshell/src/clipboard.rs
+++ b/iced_exwlshell/src/clipboard.rs
@@ -1,6 +1,19 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use exwlshellev::WindowWrapper;
 use iced_core::Clipboard;
 use iced_core::clipboard::Kind;
+
+static DISABLED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn set_disabled() {
+    DISABLED.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn is_disabled() -> bool {
+    DISABLED.load(Ordering::Relaxed)
+}
+
 pub struct LayerShellClipboard {
     state: State,
 }

--- a/iced_exwlshell/src/lib.rs
+++ b/iced_exwlshell/src/lib.rs
@@ -34,6 +34,13 @@ pub use iced_exwlshell_macros::to_exwlshell_message;
 
 pub use error::Error;
 
+/// Opt-out for clipboard initialization. Call this before starting the
+/// runtime when your app has no text input and doesn't need paste/copy —
+/// this skips spawning the always-on smithay-clipboard worker thread.
+pub fn disable_clipboard() {
+    clipboard::set_disabled();
+}
+
 pub trait FromShellInfo {
     fn get(shell: NewShellInfo) -> Self;
 }

--- a/iced_exwlshell/src/multi_window.rs
+++ b/iced_exwlshell/src/multi_window.rs
@@ -335,7 +335,14 @@ where
             new_compositor.load_font(font);
         }
         self.compositor = Some(new_compositor);
-        self.clipboard = LayerShellClipboard::connect(&window);
+        // Opt-out for clients that don't need clipboard access. Skipping
+        // connect() avoids spawning the smithay-clipboard worker thread,
+        // which otherwise runs an always-on wayland event loop (~0.4% CPU).
+        self.clipboard = if crate::clipboard::is_disabled() {
+            LayerShellClipboard::unconnected()
+        } else {
+            LayerShellClipboard::connect(&window)
+        };
         self
     }
 

--- a/iced_layershell/src/clipboard.rs
+++ b/iced_layershell/src/clipboard.rs
@@ -1,6 +1,19 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use iced_core::Clipboard;
 use iced_core::clipboard::Kind;
 use layershellev::WindowWrapper;
+
+static DISABLED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn set_disabled() {
+    DISABLED.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn is_disabled() -> bool {
+    DISABLED.load(Ordering::Relaxed)
+}
+
 pub struct LayerShellClipboard {
     state: State,
 }

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -33,6 +33,13 @@ pub use iced_layershell_macros::to_layer_message;
 
 pub use error::Error;
 
+/// Opt-out for clipboard initialization. Call this before starting the
+/// runtime when your app has no text input and doesn't need paste/copy —
+/// this skips spawning the always-on smithay-clipboard worker thread.
+pub fn disable_clipboard() {
+    clipboard::set_disabled();
+}
+
 pub type Result = std::result::Result<(), error::Error>;
 use iced_core::theme::Style as Appearance;
 

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -335,7 +335,14 @@ where
             new_compositor.load_font(font);
         }
         self.compositor = Some(new_compositor);
-        self.clipboard = LayerShellClipboard::connect(&window);
+        // Opt-out for clients that don't need clipboard access. Skipping
+        // connect() avoids spawning the smithay-clipboard worker thread,
+        // which otherwise runs an always-on wayland event loop (~0.4% CPU).
+        self.clipboard = if crate::clipboard::is_disabled() {
+            LayerShellClipboard::unconnected()
+        } else {
+            LayerShellClipboard::connect(&window)
+        };
         self
     }
 

--- a/iced_sessionlock/src/clipboard.rs
+++ b/iced_sessionlock/src/clipboard.rs
@@ -1,6 +1,18 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use iced_core::Clipboard;
 use iced_core::clipboard::Kind;
 use sessionlockev::WindowWrapper;
+
+static DISABLED: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn set_disabled() {
+    DISABLED.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn is_disabled() -> bool {
+    DISABLED.load(Ordering::Relaxed)
+}
 
 pub struct SessionLockClipboard {
     state: State,

--- a/iced_sessionlock/src/lib.rs
+++ b/iced_sessionlock/src/lib.rs
@@ -18,6 +18,13 @@ pub use error::Error;
 use iced_core::theme::Base as DefaultStyle;
 use iced_core::theme::Style as Appearance;
 
+/// Opt-out for clipboard initialization. Call this before starting the
+/// runtime when your app has no text input and doesn't need paste/copy —
+/// this skips spawning the always-on smithay-clipboard worker thread.
+pub fn disable_clipboard() {
+    clipboard::set_disabled();
+}
+
 pub type Result = std::result::Result<(), error::Error>;
 
 pub use build_pattern::application;

--- a/iced_sessionlock/src/multi_window.rs
+++ b/iced_sessionlock/src/multi_window.rs
@@ -274,7 +274,14 @@ where
             new_compositor.load_font(font);
         }
         self.compositor = Some(new_compositor);
-        self.clipboard = SessionLockClipboard::connect(&window);
+        // Opt-out for clients that don't need clipboard access. Skipping
+        // connect() avoids spawning the smithay-clipboard worker thread,
+        // which otherwise runs an always-on wayland event loop (~0.4% CPU).
+        self.clipboard = if crate::clipboard::is_disabled() {
+            SessionLockClipboard::unconnected()
+        } else {
+            SessionLockClipboard::connect(&window)
+        };
         self
     }
 


### PR DESCRIPTION
Expose `disable_clipboard()` in iced_layershell, iced_exwlshell, and iced_sessionlock so apps with no text input can skip spawning the smithay-clipboard worker thread.


## Why ?

I'm working on seing how low I could get the CPU and RAM usage in a iced-layershell based status bar. I've got it to a point where the mere existence of the clipboard worker thread is a significant part of the idle cpu usage for the project. so I'm proposing a way to disable it for apps that do not require it.