### PR TITLE
feat: add client side decoration control for XDG windows

### DIFF
--- a/exwlshellev/src/events.rs
+++ b/exwlshellev/src/events.rs
@@ -111,12 +111,15 @@ pub struct NewPopUpSettings {
     /// It means where the popup is, on which surface. It is the id of that layershell
     pub id: id::Id,
 }
-/// be used to create a new popup
+/// Settings used to create a new xdg toplevel window.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct NewXdgWindowSettings {
-    /// the size of the popup
+    /// The window title.
     pub title: Option<String>,
+    /// The initial window size.
     pub size: Option<(u32, u32)>,
+    /// Request client-side decorations instead of the default server-side mode.
+    pub client_side_decorations: bool,
 }
 
 /// input panel settings to create a new input panel surface

--- a/exwlshellev/src/lib.rs
+++ b/exwlshellev/src/lib.rs
@@ -2913,7 +2913,11 @@ impl<T: 'static> WindowState<T> {
                                 );
                             }
                             ReturnData::NewXdgBase((
-                                NewXdgWindowSettings { title, size },
+                                NewXdgWindowSettings {
+                                    title,
+                                    size,
+                                    client_side_decorations,
+                                },
                                 id,
                                 info,
                             )) => {
@@ -2928,7 +2932,11 @@ impl<T: 'static> WindowState<T> {
                                         let decoration = decoration_manager
                                             .get_toplevel_decoration(&toplevel, &qh, ());
                                         use zxdg_toplevel_decoration_v1::Mode;
-                                        decoration.set_mode(Mode::ServerSide);
+                                        decoration.set_mode(if client_side_decorations {
+                                            Mode::ClientSide
+                                        } else {
+                                            Mode::ServerSide
+                                        });
                                         Some(decoration)
                                     } else {
                                         None

--- a/iced_exwlshell/src/actions.rs
+++ b/iced_exwlshell/src/actions.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct IcedXdgWindowSettings {
+    /// The initial window size.
     pub size: Option<(u32, u32)>,
+    /// Request client-side decorations instead of the default server-side mode.
+    pub client_side_decorations: bool,
 }
 
 impl From<IcedXdgWindowSettings> for NewXdgWindowSettings {
@@ -14,6 +17,7 @@ impl From<IcedXdgWindowSettings> for NewXdgWindowSettings {
         NewXdgWindowSettings {
             title: None,
             size: val.size,
+            client_side_decorations: val.client_side_decorations,
         }
     }
 }

--- a/iced_layershell/src/actions.rs
+++ b/iced_layershell/src/actions.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct IcedXdgWindowSettings {
+    /// The initial window size.
     pub size: Option<(u32, u32)>,
+    /// Request client-side decorations instead of the default server-side mode.
+    pub client_side_decorations: bool,
 }
 
 impl From<IcedXdgWindowSettings> for NewXdgWindowSettings {
@@ -14,6 +17,7 @@ impl From<IcedXdgWindowSettings> for NewXdgWindowSettings {
         NewXdgWindowSettings {
             title: None,
             size: val.size,
+            client_side_decorations: val.client_side_decorations,
         }
     }
 }

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -111,12 +111,15 @@ pub struct NewPopUpSettings {
     /// It means where the popup is, on which surface. It is the id of that layershell
     pub id: id::Id,
 }
-/// be used to create a new popup
+/// Settings used to create a new xdg toplevel window.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct NewXdgWindowSettings {
-    /// the size of the popup
+    /// The window title.
     pub title: Option<String>,
+    /// The initial window size.
     pub size: Option<(u32, u32)>,
+    /// Request client-side decorations instead of the default server-side mode.
+    pub client_side_decorations: bool,
 }
 
 /// input panel settings to create a new input panel surface

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -2719,7 +2719,11 @@ impl<T: 'static> WindowState<T> {
                             );
                         }
                         ReturnData::NewXdgBase((
-                            NewXdgWindowSettings { title, size },
+                            NewXdgWindowSettings {
+                                title,
+                                size,
+                                client_side_decorations,
+                            },
                             id,
                             info,
                         )) => {
@@ -2735,7 +2739,11 @@ impl<T: 'static> WindowState<T> {
                                 let decoration =
                                     decoration_manager.get_toplevel_decoration(&toplevel, &qh, ());
                                 use zxdg_toplevel_decoration_v1::Mode;
-                                decoration.set_mode(Mode::ServerSide);
+                                decoration.set_mode(if client_side_decorations {
+                                    Mode::ClientSide
+                                } else {
+                                    Mode::ServerSide
+                                });
                                 Some(decoration)
                             } else {
                                 None


### PR DESCRIPTION
This adds a client side decorations option to XDG window settings so applications can request client-side decorations when desired instead of always being forced to use server-side decor. Please let me know if this needs any changes, or if this isn't desired. Thanks for your consideration!