### PR TITLE
fix: keep IME preedit text visible on transparent backgrounds

### DIFF
--- a/iced_layershell/src/ime_preedit.rs
+++ b/iced_layershell/src/ime_preedit.rs
@@ -38,7 +38,6 @@ where
         &mut self,
         cursor: Rectangle,
         preedit: &input_method::Preedit,
-        background: Color,
         renderer: &Renderer,
     ) {
         self.position = cursor.position() + Vector::new(0.0, cursor.height);
@@ -50,8 +49,7 @@ where
                         "\u{200A}"
                     } else {
                         &preedit.content[selection.start..selection.end]
-                    })
-                    .color(background),
+                    }),
                     text::Span::new(&preedit.content[selection.end..]),
                 ]
             }
@@ -116,6 +114,21 @@ where
                 background,
             );
 
+            let selection_background = Color {
+                a: color.a * 0.25,
+                ..color
+            };
+
+            for span_bounds in self.content.span_bounds(1) {
+                renderer.fill_quad(
+                    renderer::Quad {
+                        bounds: span_bounds + (bounds.position() - Point::ORIGIN),
+                        ..Default::default()
+                    },
+                    selection_background,
+                );
+            }
+
             renderer.fill_paragraph(&self.content, bounds.position(), color, bounds);
 
             const UNDERLINE: f32 = 2.0;
@@ -130,16 +143,6 @@ where
                 },
                 color,
             );
-
-            for span_bounds in self.content.span_bounds(1) {
-                renderer.fill_quad(
-                    renderer::Quad {
-                        bounds: span_bounds + (bounds.position() - Point::ORIGIN),
-                        ..Default::default()
-                    },
-                    color,
-                );
-            }
         });
     }
 }

--- a/iced_layershell/src/multi_window/window_manager.rs
+++ b/iced_layershell/src/multi_window/window_manager.rs
@@ -185,12 +185,7 @@ where
                     } else {
                         let mut overlay = self.preedit.take().unwrap_or_else(Preedit::new);
 
-                        overlay.update(
-                            cursor,
-                            &preedit,
-                            self.state.background_color(),
-                            &self.renderer,
-                        );
+                        overlay.update(cursor, &preedit, &self.renderer);
 
                         self.preedit = Some(overlay);
                     }


### PR DESCRIPTION
This changes IME preedit rendering so that the preedit text always uses the application text color.

Previously, the selected preedit span used the window background color as its text color, while the selection background used the text color. This inverse-color approach breaks when the layer-shell background is transparent: selected preedit text becomes transparent and invisible.

The new behavior keeps the preedit background transparent when the window background is transparent, renders preedit text with `text_color`, and uses a subtle translucent `text_color` fill for the selected preedit range.

This makes IME preedit readable in transparent layer-shell windows while preserving visible selection feedback.

test code
```rust
use iced::widget::{column, container, text, text_input};
use iced::{Background, Color, Element, Fill, Task, Theme};
use iced_layershell::application;
use iced_layershell::reexport::{Anchor, KeyboardInteractivity, Layer};
use iced_layershell::settings::{
    LayerShellSettings, Settings as LayerShellApplicationSettings, StartMode,
};
use iced_layershell::to_layer_message;

fn main() -> iced_layershell::Result {
    application(
        || (App::default(), Task::none()),
        "iced-ime-transparent-layer",
        App::update,
        App::view,
    )
    .theme(App::theme)
    .style(App::style)
    .settings(layer_settings())
    .run()
}

#[derive(Default)]
struct App {
    value: String,
}

#[to_layer_message]
#[derive(Debug, Clone)]
enum Message {
    Changed(String),
}

impl App {
    fn update(&mut self, message: Message) -> Task<Message> {
        if let Message::Changed(value) = message {
            self.value = value;
        }

        Task::none()
    }

    fn view(&self) -> Element<'_, Message> {
        let input = text_input("Type with a Chinese IME...", &self.value)
            .on_input(Message::Changed)
            .size(34)
            .padding(12)
            .style(|theme: &Theme, status| {
                let mut style = iced::widget::text_input::default(theme, status);
                style.background = Background::Color(Color::from_rgb8(0x1d, 0x21, 0x29));
                style.value = Color::WHITE;
                style.placeholder = Color::from_rgb8(0x9a, 0xa3, 0xb2);
                style
            });

        container(
            column![
                text("IME preedit transparent layer-shell").size(28),
                input,
                text("Use fcitx5 rime and type: ni hao"),
            ]
            .spacing(16),
        )
        .width(Fill)
        .height(Fill)
        .padding(32)
        .style(|_| {
            iced::widget::container::Style::default()
                .background(Background::Color(Color::from_rgba8(0x20, 0x24, 0x2c, 0.92)))
                .color(Color::WHITE)
        })
        .into()
    }

    fn theme(&self) -> Theme {
        Theme::Dark
    }

    fn style(&self, _theme: &Theme) -> iced::theme::Style {
        iced::theme::Style {
            background_color: Color::TRANSPARENT,
            text_color: Color::WHITE,
        }
    }
}

fn layer_settings() -> LayerShellApplicationSettings {
    LayerShellApplicationSettings {
        id: Some("iced-ime-transparent-layer".to_owned()),
        antialiasing: true,
        layer_settings: LayerShellSettings {
            anchor: Anchor::Top | Anchor::Left | Anchor::Right,
            layer: Layer::Overlay,
            exclusive_zone: 0,
            size: Some((760, 320)),
            margin: (0, 0, 0, 0),
            keyboard_interactivity: KeyboardInteractivity::Exclusive,
            start_mode: StartMode::Active,
            events_transparent: false,
        },
        ..LayerShellApplicationSettings::default()
    }
}

```

before
<img width="1009" height="414" alt="foamshot-2026-05-21-23-25-26" src="https://github.com/user-attachments/assets/9df6f378-1e7f-4b89-b3f5-55fd158dcb4e" />
now
<img width="996" height="419" alt="foamshot-2026-05-21-23-24-55" src="https://github.com/user-attachments/assets/4c0aedee-4e80-46ac-b7a7-e3d480cb5604" />

I think the current approach is more reasonable.