### PR TITLE
fix: None option cannot work in layershellev and exwlshellev, and replace None with Active

### DIFF
--- a/exwlshellev/src/events.rs
+++ b/exwlshellev/src/events.rs
@@ -84,6 +84,10 @@ pub enum OutputOption {
     /// want to pass a [wl_output::WlOutput] to create a new layershell, you need to pass your
     /// connection to layershellev first
     Output(wl_output::WlOutput),
+
+    /// Let the compositor decide which output to use.
+    Active,
+
     #[default]
     None,
 }
@@ -165,7 +169,7 @@ impl Default for NewLayerShellSettings {
             size: None,
             margin: Some((0, 0, 0, 0)),
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
-            output_option: OutputOption::None,
+            output_option: OutputOption::Active,
             events_transparent: false,
             namespace: None,
         }

--- a/exwlshellev/src/events.rs
+++ b/exwlshellev/src/events.rs
@@ -86,10 +86,8 @@ pub enum OutputOption {
     Output(wl_output::WlOutput),
 
     /// Let the compositor decide which output to use.
-    Active,
-
     #[default]
-    None,
+    Active,
 }
 
 /// layershell settings to create a new layershell surface

--- a/exwlshellev/src/lib.rs
+++ b/exwlshellev/src/lib.rs
@@ -1086,6 +1086,17 @@ impl<T> WindowState<T> {
     pub fn forget_last_output(&mut self) {
         self.last_wloutput.take();
     }
+
+    fn last_output(&mut self) -> Option<WlOutput> {
+        if self.last_wloutput.is_none() {
+            self.last_wloutput = self.outputs.get(self.last_unit_index).cloned();
+        }
+
+        self.last_wloutput
+            .as_ref()
+            .or_else(|| self.outputs.first())
+            .cloned()
+    }
 }
 
 /// Simple WindowState, without any data binding or info
@@ -2803,7 +2814,8 @@ impl<T: 'static> WindowState<T> {
                                         .iter()
                                         .find(|(_, info)| info.name == *name)
                                         .map(|(output, _)| output.clone()),
-                                    _ => None,
+                                    OutputOption::Active => None,
+                                    OutputOption::LastOutput => window_state.last_output(),
                                 };
 
                                 let wl_surface = wmcompositer.create_surface(&qh, ());
@@ -3065,7 +3077,8 @@ impl<T: 'static> WindowState<T> {
                                         .iter()
                                         .find(|(_, info)| info.name == *name)
                                         .map(|(output, _)| output.clone()),
-                                    _ => None,
+                                    OutputOption::Active => None,
+                                    OutputOption::LastOutput => window_state.last_output(),
                                 };
 
                                 let Some(output) = output else {

--- a/exwlshellev/src/lib.rs
+++ b/exwlshellev/src/lib.rs
@@ -1589,12 +1589,6 @@ impl<T> WindowState<T> {
         self.units.iter()
     }
 
-    fn surface_pos(&self) -> Option<usize> {
-        self.units
-            .iter()
-            .position(|unit| Some(&unit.wl_surface) == self.current_surface.as_ref())
-    }
-
     /// get the current focused surface id
     pub fn current_surface_id(&self) -> Option<id::Id> {
         self.units
@@ -2809,32 +2803,7 @@ impl<T: 'static> WindowState<T> {
                                         .iter()
                                         .find(|(_, info)| info.name == *name)
                                         .map(|(output, _)| output.clone()),
-                                    _ => {
-                                        let pos = window_state.surface_pos();
-
-                                        let mut output = pos
-                                            .and_then(|p| window_state.units[p].wl_output.as_ref());
-
-                                        if window_state.last_wloutput.is_none()
-                                            && window_state.outputs.len()
-                                                > window_state.last_unit_index
-                                        {
-                                            window_state.last_wloutput = Some(
-                                                window_state.outputs[window_state.last_unit_index]
-                                                    .clone(),
-                                            );
-                                        }
-
-                                        if matches!(output_type, events::OutputOption::LastOutput) {
-                                            output = window_state.last_wloutput.as_ref();
-                                        }
-
-                                        if output.is_none() {
-                                            output = window_state.outputs.first();
-                                        }
-
-                                        output.cloned()
-                                    }
+                                    _ => None,
                                 };
 
                                 let wl_surface = wmcompositer.create_surface(&qh, ());
@@ -3096,32 +3065,7 @@ impl<T: 'static> WindowState<T> {
                                         .iter()
                                         .find(|(_, info)| info.name == *name)
                                         .map(|(output, _)| output.clone()),
-                                    _ => {
-                                        let pos = window_state.surface_pos();
-
-                                        let mut output = pos
-                                            .and_then(|p| window_state.units[p].wl_output.as_ref());
-
-                                        if window_state.last_wloutput.is_none()
-                                            && window_state.outputs.len()
-                                                > window_state.last_unit_index
-                                        {
-                                            window_state.last_wloutput = Some(
-                                                window_state.outputs[window_state.last_unit_index]
-                                                    .clone(),
-                                            );
-                                        }
-
-                                        if matches!(output_type, events::OutputOption::LastOutput) {
-                                            output = window_state.last_wloutput.as_ref();
-                                        }
-
-                                        if output.is_none() {
-                                            output = window_state.outputs.first();
-                                        }
-
-                                        output.cloned()
-                                    }
+                                    _ => None,
                                 };
 
                                 let Some(output) = output else {

--- a/iced_examples/multi_window/src/main.rs
+++ b/iced_examples/multi_window/src/main.rs
@@ -82,7 +82,7 @@ impl Example {
                     layer: Layer::Top,
                     margin: None,
                     //keyboard_interactivity: KeyboardInteractivity::None,
-                    output_option: OutputOption::None,
+                    output_option: OutputOption::Active,
                     ..Default::default()
                 },
                 id,

--- a/iced_examples/zbus_invoked_widget/src/main.rs
+++ b/iced_examples/zbus_invoked_widget/src/main.rs
@@ -126,7 +126,7 @@ impl Counter {
                         layer: Layer::Top,
                         margin: Some((100, 100, 100, 100)),
                         keyboard_interactivity: KeyboardInteractivity::OnDemand,
-                        output_option: OutputOption::None,
+                        output_option: OutputOption::Active,
                         ..Default::default()
                     },
                     id: iced::window::Id::unique(),

--- a/iced_layershell/src/build_pattern/daemon.md
+++ b/iced_layershell/src/build_pattern/daemon.md
@@ -197,7 +197,7 @@ impl Counter {
                         layer: Layer::Top,
                         margin: None,
                         keyboard_interactivity: KeyboardInteractivity::Exclusive,
-                        output_option: OutputOption::None,
+                        output_option: OutputOption::Active,
                         ..Default::default()
                     },
                     id,
@@ -214,7 +214,7 @@ impl Counter {
                         layer: Layer::Top,
                         margin: None,
                         keyboard_interactivity: KeyboardInteractivity::Exclusive,
-                        output_option: OutputOption::None,
+                        output_option: OutputOption::Active,
                         ..Default::default()
                     },
                     id,

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -84,6 +84,10 @@ pub enum OutputOption {
     /// want to pass a [wl_output::WlOutput] to create a new layershell, you need to pass your
     /// connection to layershellev first
     Output(wl_output::WlOutput),
+
+    /// Let the compositor decide which output to use.
+    Active,
+
     #[default]
     None,
 }
@@ -165,7 +169,7 @@ impl Default for NewLayerShellSettings {
             size: None,
             margin: Some((0, 0, 0, 0)),
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
-            output_option: OutputOption::None,
+            output_option: OutputOption::Active,
             events_transparent: false,
             namespace: None,
         }

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -86,10 +86,8 @@ pub enum OutputOption {
     Output(wl_output::WlOutput),
 
     /// Let the compositor decide which output to use.
-    Active,
-
     #[default]
-    None,
+    Active,
 }
 
 /// layershell settings to create a new layershell surface

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -1045,6 +1045,17 @@ impl<T> WindowState<T> {
     pub fn forget_last_output(&mut self) {
         self.last_wloutput.take();
     }
+
+    fn last_output(&mut self) -> Option<WlOutput> {
+        if self.last_wloutput.is_none() {
+            self.last_wloutput = self.outputs.get(self.last_unit_index).cloned();
+        }
+
+        self.last_wloutput
+            .as_ref()
+            .or_else(|| self.outputs.first())
+            .cloned()
+    }
 }
 
 /// Simple WindowState, without any data binding or info
@@ -2609,7 +2620,8 @@ impl<T: 'static> WindowState<T> {
                                     .iter()
                                     .find(|(_, info)| info.name == *name)
                                     .map(|(output, _)| output.clone()),
-                                _ => None,
+                                OutputOption::Active => None,
+                                OutputOption::LastOutput => window_state.last_output(),
                             };
 
                             let wl_surface = wmcompositer.create_surface(&qh, ());
@@ -2870,7 +2882,8 @@ impl<T: 'static> WindowState<T> {
                                     .iter()
                                     .find(|(_, info)| info.name == *name)
                                     .map(|(output, _)| output.clone()),
-                                _ => None,
+                                OutputOption::Active => None,
+                                OutputOption::LastOutput => window_state.last_output(),
                             };
 
                             let Some(output) = output else {

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -1546,12 +1546,6 @@ impl<T> WindowState<T> {
         self.units.iter()
     }
 
-    fn surface_pos(&self) -> Option<usize> {
-        self.units
-            .iter()
-            .position(|unit| Some(&unit.wl_surface) == self.current_surface.as_ref())
-    }
-
     /// get the current focused surface id
     pub fn current_surface_id(&self) -> Option<id::Id> {
         self.units
@@ -2615,31 +2609,7 @@ impl<T: 'static> WindowState<T> {
                                     .iter()
                                     .find(|(_, info)| info.name == *name)
                                     .map(|(output, _)| output.clone()),
-                                _ => {
-                                    let pos = window_state.surface_pos();
-
-                                    let mut output =
-                                        pos.and_then(|p| window_state.units[p].wl_output.as_ref());
-
-                                    if window_state.last_wloutput.is_none()
-                                        && window_state.outputs.len() > window_state.last_unit_index
-                                    {
-                                        window_state.last_wloutput = Some(
-                                            window_state.outputs[window_state.last_unit_index]
-                                                .clone(),
-                                        );
-                                    }
-
-                                    if matches!(output_type, events::OutputOption::LastOutput) {
-                                        output = window_state.last_wloutput.as_ref();
-                                    }
-
-                                    if output.is_none() {
-                                        output = window_state.outputs.first();
-                                    }
-
-                                    output.cloned()
-                                }
+                                _ => None,
                             };
 
                             let wl_surface = wmcompositer.create_surface(&qh, ());
@@ -2900,31 +2870,7 @@ impl<T: 'static> WindowState<T> {
                                     .iter()
                                     .find(|(_, info)| info.name == *name)
                                     .map(|(output, _)| output.clone()),
-                                _ => {
-                                    let pos = window_state.surface_pos();
-
-                                    let mut output =
-                                        pos.and_then(|p| window_state.units[p].wl_output.as_ref());
-
-                                    if window_state.last_wloutput.is_none()
-                                        && window_state.outputs.len() > window_state.last_unit_index
-                                    {
-                                        window_state.last_wloutput = Some(
-                                            window_state.outputs[window_state.last_unit_index]
-                                                .clone(),
-                                        );
-                                    }
-
-                                    if matches!(output_type, events::OutputOption::LastOutput) {
-                                        output = window_state.last_wloutput.as_ref();
-                                    }
-
-                                    if output.is_none() {
-                                        output = window_state.outputs.first();
-                                    }
-
-                                    output.cloned()
-                                }
+                                _ => None,
                             };
 
                             let Some(output) = output else {


### PR DESCRIPTION
A way to let compositor to decide output, just pass `NULL` to `get_layer_surface`.

Refrence: [ref](https://gitlab.freedesktop.org/wlroots/wlr-protocols/-/blob/master/unstable%2Fwlr-layer-shell-unstable-v1.xml?blame=1#L56)