### PR TITLE
feat: track outputs via sctk OutputState & add OutputChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed (breaking)
+- Feat: track outputs with sctk's `OutputState` instead of manual `zxdg_output_v1` handling, removed `XdgInfoChanged` event, `XdgInfoChangedType`, `ZxdgOutputInfo` and `get_xdgoutput_info`
+- Feat: new `DispatchMessage::OutputChanged` event sent when surface enters another output or its output info changes
+
+### Changed
+- Feat: add `WindowState::outputs()`, `output_by_name()`, `get_output_info()`, `get_output_info_of()` and `WindowStateUnit::get_wloutput()`
+- Feat: add `output::listen()` subscription to iced_layershell and iced_exwlshell to track the output a window is displayed on
+
 ## [0.19.1] - 2026-07-12
 ### Changed
 - Make the fields of LocalRegion in iced_wayland_subscriber public

--- a/exwlshellev/examples/simpleshell.rs
+++ b/exwlshellev/examples/simpleshell.rs
@@ -17,7 +17,7 @@ fn main() {
         .build()
         .unwrap();
 
-    ev.running(move |event, ev, index| {
+    ev.running(move |event, ev, _index| {
         match event {
             // NOTE: this will send when init, you can request bind extra object from here
             ExWlShellEvent::InitRequest => ReturnData::RequestBind,
@@ -42,12 +42,6 @@ fn main() {
                     region.add(0, 0, 0, 0);
                     x.get_wlsurface().set_input_region(Some(&region));
                 }
-                ReturnData::None
-            }
-            ExWlShellEvent::XdgInfoChanged(_) => {
-                let index = index.unwrap();
-                let unit = ev.get_unit_with_id(index).unwrap();
-                println!("{:?}", unit.get_xdgoutput_info());
                 ReturnData::None
             }
             ExWlShellEvent::RequestBuffer(file, shm, qh, init_w, init_h) => {
@@ -83,6 +77,12 @@ fn main() {
                 surface_y,
             }) => {
                 println!("{time}, {surface_x}, {surface_y}");
+                ReturnData::None
+            }
+            ExWlShellEvent::RequestMessages(DispatchMessage::OutputChanged(output)) => {
+                // NOTE: sent when surface enters another output, or its output info changes
+                let info = output.as_ref().and_then(|o| ev.get_output_info_of(o));
+                println!("{info:?}");
                 ReturnData::None
             }
             ExWlShellEvent::RequestMessages(DispatchMessage::KeyboardInput { event, .. }) => {

--- a/exwlshellev/src/events.rs
+++ b/exwlshellev/src/events.rs
@@ -46,8 +46,6 @@ pub enum ExWlShellEvent<'a, T, Message> {
     /// [ReturnData::RequestBind], then it will continue to the next request.
     /// Here only the above two [ReturnData] are acceptable.
     InitRequest,
-    /// if the info of the XdgOutput is changed, it will send the event
-    XdgInfoChanged(XdgInfoChangedType),
     /// After you return [ReturnData::RequestBind] in the [LayerShellEvent::InitRequest] stage, next
     /// event is [LayerShellEvent::BindProvide], you can use the GlobalList and QueueHandle to create
     /// new wayland objects.
@@ -205,15 +203,6 @@ pub enum ReturnData<INFO> {
     None,
 }
 
-/// this tell the what kind of information passed by [LayerShellEvent::XdgInfoChanged]
-#[derive(Debug, Clone, Copy)]
-pub enum XdgInfoChangedType {
-    Position,
-    Size,
-    Name,
-    Description,
-}
-
 /// Describes a scroll along one axis
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct AxisScroll {
@@ -339,7 +328,7 @@ pub(crate) enum DispatchMessageInner {
         scale_u32: u32,
         scale_float: f64,
     },
-    XdgInfoChanged(XdgInfoChangedType),
+    OutputChanged(Option<WlOutput>),
     Ime(Ime),
 }
 
@@ -438,6 +427,8 @@ pub enum DispatchMessage {
         scale_float: f64,
     },
     Ime(Ime),
+    /// surface entered output, or left the one it was on
+    OutputChanged(Option<WlOutput>),
     Closed,
 }
 
@@ -542,7 +533,7 @@ impl From<DispatchMessageInner> for DispatchMessage {
                 scale_float,
             },
             DispatchMessageInner::Ime(ime) => DispatchMessage::Ime(ime),
-            DispatchMessageInner::XdgInfoChanged(_) => unimplemented!(),
+            DispatchMessageInner::OutputChanged(output) => DispatchMessage::OutputChanged(output),
         }
     }
 }

--- a/exwlshellev/src/lib.rs
+++ b/exwlshellev/src/lib.rs
@@ -38,12 +38,6 @@
 //!                 println!("{:?}", virtual_keyboard_manager);
 //!                 ReturnData::None
 //!             }
-//!             ExWlShellEvent::XdgInfoChanged(_) => {
-//!                 let index = index.unwrap();
-//!                 let unit = ev.get_unit_with_id(index).unwrap();
-//!                 println!("{:?}", unit.get_xdgoutput_info());
-//!                 ReturnData::None
-//!             }
 //!             ExWlShellEvent::RequestBuffer(file, shm, qh, init_w, init_h) => {
 //!                 draw(file, (init_w, init_h));
 //!                 let pool = shm.create_pool(file.as_fd(), (init_w * init_h * 4) as i32, qh, ());
@@ -112,6 +106,7 @@ pub use events::NewLayerShellSettings;
 pub use events::NewXdgWindowSettings;
 pub use events::OutputOption;
 pub use events::{NewPopUpSettings, PopupPlacement};
+pub use sctk::output::OutputInfo;
 pub use waycrate_xkbkeycode::keyboard;
 pub use waycrate_xkbkeycode::xkb_keyboard;
 
@@ -124,9 +119,7 @@ use events::DispatchMessageInner;
 
 pub mod id;
 
-pub use events::{
-    AxisScroll, DispatchMessage, ExWlShellEvent, Ime, ReturnData, XdgInfoChangedType,
-};
+pub use events::{AxisScroll, DispatchMessage, ExWlShellEvent, Ime, ReturnData};
 
 use strtoshape::str_to_shape;
 
@@ -179,15 +172,9 @@ use wayland_protocols::xdg::shell::client::{
     xdg_wm_base::{self, XdgWmBase},
 };
 
-use wayland_protocols::{
-    wp::fractional_scale::v1::client::{
-        wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1,
-        wp_fractional_scale_v1::{self, WpFractionalScaleV1},
-    },
-    xdg::xdg_output::zv1::client::{
-        zxdg_output_manager_v1::ZxdgOutputManagerV1,
-        zxdg_output_v1::{self, ZxdgOutputV1},
-    },
+use wayland_protocols::wp::fractional_scale::v1::client::{
+    wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1,
+    wp_fractional_scale_v1::{self, WpFractionalScaleV1},
 };
 
 use wayland_protocols::wp::input_method::zv1::client::{
@@ -298,38 +285,6 @@ pub mod reexport {
     }
     pub mod wp_viewport {
         pub use wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
-    }
-}
-
-/// this struct store the xdg_output information
-#[derive(Debug, Clone)]
-pub struct ZxdgOutputInfo {
-    name: String,
-    description: String,
-    zxdgoutput: ZxdgOutputV1,
-    logical_size: (i32, i32),
-    position: (i32, i32),
-}
-
-impl ZxdgOutputInfo {
-    fn new(zxdgoutput: ZxdgOutputV1) -> Self {
-        Self {
-            zxdgoutput,
-            name: "".to_owned(),
-            description: "".to_owned(),
-            logical_size: (0, 0),
-            position: (0, 0),
-        }
-    }
-
-    /// you can get the Logic position of the screen current surface in
-    pub fn get_position(&self) -> (i32, i32) {
-        self.position
-    }
-
-    /// you can get the LogicalPosition of the screen current surface in
-    pub fn get_logical_size(&self) -> (i32, i32) {
-        self.logical_size
     }
 }
 
@@ -468,7 +423,6 @@ impl<T> WindowStateUnitBuilder<T> {
                 parent: None,
                 size: (0, 0),
                 buffer: Default::default(),
-                zxdgoutput: Default::default(),
                 fractional_scale: Default::default(),
                 viewport: Default::default(),
                 wl_output: Default::default(),
@@ -489,11 +443,6 @@ impl<T> WindowStateUnitBuilder<T> {
 
     fn size(mut self, size: (u32, u32)) -> Self {
         self.inner.size = size;
-        self
-    }
-
-    fn zxdgoutput(mut self, zxdgoutput: Option<ZxdgOutputInfo>) -> Self {
-        self.inner.zxdgoutput = zxdgoutput;
         self
     }
 
@@ -559,7 +508,6 @@ pub struct WindowStateUnit<T> {
     buffer: Option<WlBuffer>,
     shell: Shell,
     parent: Option<id::Id>,
-    zxdgoutput: Option<ZxdgOutputInfo>,
     fractional_scale: Option<WpFractionalScaleV1>,
     viewport: Option<WpViewport>,
     wl_output: Option<WlOutput>,
@@ -687,9 +635,9 @@ impl<T> WindowStateUnit<T> {
         &self.wl_surface
     }
 
-    /// get the xdg_output info related to this unit
-    pub fn get_xdgoutput_info(&self) -> Option<&ZxdgOutputInfo> {
-        self.zxdgoutput.as_ref()
+    /// output this surface is displayed on from compositor through `wl_surface::enter`
+    pub fn get_wloutput(&self) -> Option<&WlOutput> {
+        self.wl_output.as_ref()
     }
 
     /// set the anchor of the current unit. please take the simple.rs as reference
@@ -960,7 +908,6 @@ pub struct WindowState<T> {
     connection: Option<Connection>,
     event_queue: Option<EventQueue<WindowState<T>>>,
     wl_compositor: Option<WlCompositor>,
-    xdg_output_manager: Option<ZxdgOutputManagerV1>,
     wmbase: Option<XdgWmBase>,
     shm: Option<WlShm>,
     cursor_manager: Option<WpCursorShapeManagerV1>,
@@ -1006,8 +953,6 @@ pub struct WindowState<T> {
     finger_locations: HashMap<i32, (f64, f64)>,
     enter_serial: Option<u32>,
     button_serial: Option<u32>,
-
-    xdg_info_cache: Vec<(wl_output::WlOutput, ZxdgOutputInfo)>,
 
     start_mode: StartMode,
     init_finished: bool,
@@ -1518,7 +1463,6 @@ impl<T> Default for WindowState<T> {
             cursor_manager: None,
             lock_manager: None,
             viewporter: None,
-            xdg_output_manager: None,
             globals: None,
             fractional_scale_manager: None,
             virtual_keyboard: None,
@@ -1551,9 +1495,6 @@ impl<T> Default for WindowState<T> {
             finger_locations: HashMap::new(),
             enter_serial: None,
             button_serial: None,
-            // NOTE: if is some, means it is to be binded, but not now it
-            // is not binded
-            xdg_info_cache: Vec::new(),
 
             start_mode: StartMode::Active,
             init_finished: false,
@@ -1598,6 +1539,36 @@ impl<T> WindowState<T> {
     /// it return the iter of units. you can do loop with it
     pub fn get_unit_iter(&self) -> impl Iterator<Item = &WindowStateUnit<T>> {
         self.units.iter()
+    }
+
+    /// every output the compositor advertises with its info
+    pub fn outputs(&self) -> Vec<(WlOutput, OutputInfo)> {
+        let Some(state) = self.output_state.as_ref() else {
+            return Vec::new();
+        };
+        state
+            .outputs()
+            .filter_map(|output| state.info(&output).map(|info| (output, info)))
+            .collect()
+    }
+
+    /// the info of a given output, if it is still known.
+    pub fn get_output_info_of(&self, output: &WlOutput) -> Option<OutputInfo> {
+        self.output_state.as_ref()?.info(output)
+    }
+
+    /// the output matching `name` (`HDMI-A-1` and such), if it is connected.
+    pub fn output_by_name(&self, name: &str) -> Option<WlOutput> {
+        let state = self.output_state.as_ref()?;
+        state
+            .outputs()
+            .find(|output| state.info(output).and_then(|info| info.name).as_deref() == Some(name))
+    }
+
+    /// the output info the surface `id` is currently displayed on
+    pub fn get_output_info(&self, id: id::Id) -> Option<OutputInfo> {
+        let output = self.get_unit_with_id(id)?.wl_output.clone()?;
+        self.get_output_info_of(&output)
     }
 
     /// get the current focused surface id
@@ -1700,8 +1671,20 @@ impl<T: 'static> OutputHandler for WindowState<T> {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
+        output: wl_output::WlOutput,
     ) {
+        let affected: Vec<id::Id> = self
+            .units
+            .iter()
+            .filter(|unit| unit.wl_output.as_ref() == Some(&output))
+            .map(|unit| unit.id)
+            .collect();
+        for id in affected {
+            self.message.push((
+                Some(id),
+                DispatchMessageInner::OutputChanged(Some(output.clone())),
+            ));
+        }
     }
     fn output_destroyed(
         &mut self,
@@ -1716,11 +1699,7 @@ impl<T: 'static> OutputHandler for WindowState<T> {
         {
             self.last_wloutput.take();
         }
-        let outputs_removed = self.outputs.extract_if(.., |o| o == &output);
-        for output_removed in outputs_removed {
-            self.xdg_info_cache
-                .retain(|info| info.0.id() != output_removed.id());
-        }
+        self.outputs.retain(|o| o != &output);
 
         let removed_states = self.units.extract_if(.., |unit| {
             !unit.wl_surface.is_alive()
@@ -1881,74 +1860,6 @@ impl<T> Dispatch<xdg_popup::XdgPopup, ()> for WindowState<T> {
     }
 }
 
-impl<T> Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for WindowState<T> {
-    fn event(
-        state: &mut Self,
-        proxy: &zxdg_output_v1::ZxdgOutputV1,
-        event: <zxdg_output_v1::ZxdgOutputV1 as Proxy>::Event,
-        _data: &(),
-        _conn: &Connection,
-        _qhandle: &QueueHandle<Self>,
-    ) {
-        if let Some((_, xdg_info)) = state
-            .xdg_info_cache
-            .iter_mut()
-            .find(|(_, info)| info.zxdgoutput == *proxy)
-        {
-            match event {
-                zxdg_output_v1::Event::LogicalSize { width, height } => {
-                    xdg_info.logical_size = (width, height);
-                }
-                zxdg_output_v1::Event::LogicalPosition { x, y } => {
-                    xdg_info.position = (x, y);
-                }
-                zxdg_output_v1::Event::Name { ref name } => {
-                    xdg_info.name = name.clone();
-                }
-                zxdg_output_v1::Event::Description { ref description } => {
-                    xdg_info.description = description.clone();
-                }
-                _ => {}
-            };
-        }
-
-        let Some(index) = state.units.iter().position(|info| {
-            info.zxdgoutput
-                .as_ref()
-                .is_some_and(|zxdgoutput| zxdgoutput.zxdgoutput == *proxy)
-        }) else {
-            return;
-        };
-        let info = &mut state.units[index];
-        let xdg_info = info.zxdgoutput.as_mut().unwrap();
-        let change_type = match event {
-            zxdg_output_v1::Event::LogicalSize { width, height } => {
-                xdg_info.logical_size = (width, height);
-                XdgInfoChangedType::Size
-            }
-            zxdg_output_v1::Event::LogicalPosition { x, y } => {
-                xdg_info.position = (x, y);
-                XdgInfoChangedType::Position
-            }
-            zxdg_output_v1::Event::Name { name } => {
-                xdg_info.name = name;
-                XdgInfoChangedType::Name
-            }
-            zxdg_output_v1::Event::Description { description } => {
-                xdg_info.description = description;
-                XdgInfoChangedType::Description
-            }
-            _ => {
-                return;
-            }
-        };
-        state.message.push((
-            Some(state.units[index].id),
-            DispatchMessageInner::XdgInfoChanged(change_type),
-        ));
-    }
-}
-
 impl<T> Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, ()> for WindowState<T> {
     fn event(
         state: &mut Self,
@@ -1994,9 +1905,11 @@ impl<T> Dispatch<WlSurface, ()> for WindowState<T> {
         else {
             return;
         };
-        match event {
+        let id = unit.id;
+        let changed = match event {
             wl_surface::Event::Enter { output } => {
-                unit.wl_output.replace(output);
+                let previous = unit.wl_output.replace(output);
+                previous.as_ref() != unit.wl_output.as_ref()
             }
             wl_surface::Event::Leave { output }
                 if !matches!(unit.shell, Shell::LayerShell(..))
@@ -2006,8 +1919,15 @@ impl<T> Dispatch<WlSurface, ()> for WindowState<T> {
                         .is_some_and(|i_output| i_output == &output) =>
             {
                 unit.wl_output.take();
+                true
             }
-            _ => {}
+            _ => false,
+        };
+        if changed {
+            let output = unit.wl_output.clone();
+            state
+                .message
+                .push((Some(id), DispatchMessageInner::OutputChanged(output)));
         }
     }
 }
@@ -2180,7 +2100,6 @@ delegate_noop!(@<T> WindowState<T>: ignore WpViewport);
 delegate_noop!(@<T> WindowState<T>: ignore ZwpVirtualKeyboardV1);
 delegate_noop!(@<T> WindowState<T>: ignore ZwpVirtualKeyboardManagerV1);
 
-delegate_noop!(@<T> WindowState<T>: ignore ZxdgOutputManagerV1);
 delegate_noop!(@<T> WindowState<T>: ignore WpFractionalScaleManagerV1);
 delegate_noop!(@<T> WindowState<T>: ignore XdgPositioner);
 delegate_noop!(@<T> WindowState<T>: ignore ExtSessionLockV1); // buffer show the picture
@@ -2249,9 +2168,6 @@ impl<T: 'static> WindowState<T> {
 
         // register this
 
-        let xdg_output_manager = globals.bind::<ZxdgOutputManagerV1, _, _>(&qh, 1..=3, ())?; // bind
-        // xdg_output_manager
-
         let decoration_manager = globals
             .bind::<ZxdgDecorationManagerV1, _, _>(&qh, 1..=1, ())
             .ok();
@@ -2269,17 +2185,11 @@ impl<T: 'static> WindowState<T> {
         self.text_input_manager = text_input_manager;
         event_queue.blocking_dispatch(&mut self)?; // then make a dispatch
 
-        // do the step before, you get empty list
-
-        for output_display in &self.outputs {
-            let zxdgoutput = xdg_output_manager.get_xdg_output(output_display, &qh, ());
-            self.xdg_info_cache
-                .push((output_display.clone(), ZxdgOutputInfo::new(zxdgoutput)));
-        }
-        event_queue.blocking_dispatch(&mut self)?; // then make a dispatch
-        // so it is the same way, to get surface detach to protocol, first get the shell, like wmbase
-        // or layer_shell or session-shell, then get `surface` from the wl_surface you get before, and
-        // set it
+        // OutputState bound its own xdg_outputs before the dispatch above, so output info is
+        // populated by now, a second roundtrip is not needed
+        // so it is the same way, to get surface detach to protocol, first get the shell, like
+        // wmbase or layer_shell or session-shell, then get `surface` from the wl_surface you
+        // get before, and set it
         // finally thing to remember is to commit the surface, make the shell to init.
         //let (init_w, init_h) = self.size;
         // this example is ok for both xdg_surface and layer_shell
@@ -2292,24 +2202,10 @@ impl<T: 'static> WindowState<T> {
             }
             self.background_surface = Some(background_surface);
         } else if !self.is_allscreens() {
-            let mut output = None;
-
-            let (binded_output, binded_xdginfo) = match self.start_mode.clone() {
-                StartMode::TargetScreen(name) => {
-                    if let Some(cache) = self
-                        .xdg_info_cache
-                        .iter()
-                        .find(|(_, info)| info.name == *name)
-                        .cloned()
-                    {
-                        output = Some(cache.clone());
-                    }
-                    let binded_output = output.as_ref().map(|(output, _)| output).cloned();
-                    let binded_xdginfo = output.as_ref().map(|(_, xdginfo)| xdginfo).cloned();
-                    (binded_output, binded_xdginfo)
-                }
-                StartMode::TargetOutput(output) => (Some(output), None),
-                _ => (None, None),
+            let binded_output = match self.start_mode.clone() {
+                StartMode::TargetScreen(name) => self.output_by_name(&name),
+                StartMode::TargetOutput(output) => Some(output),
+                _ => None,
             };
 
             let wl_surface = wmcompositer.create_surface(&qh, ()); // and create a surface. if two or more,
@@ -2367,7 +2263,6 @@ impl<T: 'static> WindowState<T> {
                     Shell::LayerShell(layer),
                 )
                 .viewport(viewport)
-                .zxdgoutput(binded_xdginfo)
                 .fractional_scale(fractional_scale)
                 .wl_output(binded_output.clone())
                 .build(),
@@ -2408,7 +2303,6 @@ impl<T: 'static> WindowState<T> {
                 }
                 wl_surface.commit();
 
-                let zxdgoutput = xdg_output_manager.get_xdg_output(output_display, &qh, ());
                 let mut fractional_scale = None;
                 if let Some(ref fractional_scale_manager) = fractional_scale_manager {
                     fractional_scale =
@@ -2431,7 +2325,6 @@ impl<T: 'static> WindowState<T> {
                         Shell::LayerShell(layer),
                     )
                     .viewport(viewport)
-                    .zxdgoutput(Some(ZxdgOutputInfo::new(zxdgoutput)))
                     .fractional_scale(fractional_scale)
                     .wl_output(Some(output_display.clone()))
                     .build(),
@@ -2447,7 +2340,6 @@ impl<T: 'static> WindowState<T> {
         self.fractional_scale_manager = fractional_scale_manager;
         self.cursor_manager = cursor_manager;
         self.lock_manager = Some(lock_manager);
-        self.xdg_output_manager = Some(xdg_output_manager);
         self.connection = Some(connection);
 
         Ok(self)
@@ -2501,7 +2393,6 @@ impl<T: 'static> WindowState<T> {
         let shm = self.shm.take().unwrap();
         let fractional_scale_manager = self.fractional_scale_manager.take();
         let cursor_manager: Option<WpCursorShapeManagerV1> = self.cursor_manager.take();
-        let xdg_output_manager = self.xdg_output_manager.take().unwrap();
         let connection = self.connection.take().unwrap();
         let mut init_event = None;
         let wmbase = self.wmbase.take().unwrap();
@@ -2573,24 +2464,8 @@ impl<T: 'static> WindowState<T> {
                 std::mem::swap(&mut messages, &mut window_state.message);
                 for msg in messages.iter() {
                     match msg {
-                        (index_info, DispatchMessageInner::XdgInfoChanged(change_type)) => {
-                            window_state.handle_event(
-                                &mut *event_handler,
-                                ExWlShellEvent::XdgInfoChanged(*change_type),
-                                *index_info,
-                            );
-                        }
                         (_, DispatchMessageInner::NewDisplay(output_display)) => {
-                            let zxdgoutput =
-                                xdg_output_manager.get_xdg_output(output_display, &qh, ());
-
-                            window_state.xdg_info_cache.push((
-                                output_display.clone(),
-                                ZxdgOutputInfo::new(zxdgoutput.clone()),
-                            ));
                             if let Some(lock) = lock {
-                                let zxdgoutput =
-                                    xdg_output_manager.get_xdg_output(output_display, &qh, ());
                                 let wl_surface = wmcompositer.create_surface(&qh, ()); // and create a surface. if two or more,
                                 wl_surface.commit();
                                 let session_lock_surface =
@@ -2623,7 +2498,6 @@ impl<T: 'static> WindowState<T> {
                                         Shell::SessionLock(session_lock_surface),
                                     )
                                     .viewport(viewport)
-                                    .zxdgoutput(Some(ZxdgOutputInfo::new(zxdgoutput)))
                                     .fractional_scale(fractional_scale)
                                     .wl_output(Some(output_display.clone()))
                                     .build(),
@@ -2688,7 +2562,6 @@ impl<T: 'static> WindowState<T> {
                                     Shell::LayerShell(layer),
                                 )
                                 .viewport(viewport)
-                                .zxdgoutput(Some(ZxdgOutputInfo::new(zxdgoutput)))
                                 .fractional_scale(fractional_scale)
                                 .wl_output(Some(output_display.clone()))
                                 .build(),
@@ -2726,8 +2599,6 @@ impl<T: 'static> WindowState<T> {
                                 let l_lock = lock_manager.lock(&qh, ());
                                 let wl_outputs = window_state.outputs.clone();
                                 for wl_output in wl_outputs.iter() {
-                                    let zxdgoutput =
-                                        xdg_output_manager.get_xdg_output(wl_output, &qh, ());
                                     let wl_surface = wmcompositer.create_surface(&qh, ()); // and create a surface. if two or more,
                                     wl_surface.commit();
                                     let session_lock_surface =
@@ -2761,7 +2632,6 @@ impl<T: 'static> WindowState<T> {
                                             Shell::SessionLock(session_lock_surface),
                                         )
                                         .viewport(viewport)
-                                        .zxdgoutput(Some(ZxdgOutputInfo::new(zxdgoutput)))
                                         .fractional_scale(fractional_scale)
                                         .wl_output(Some(wl_output.clone()))
                                         .build(),
@@ -2809,11 +2679,9 @@ impl<T: 'static> WindowState<T> {
                             )) => {
                                 let output = match output_type {
                                     OutputOption::Output(output) => Some(output),
-                                    OutputOption::OutputName(name) => window_state
-                                        .xdg_info_cache
-                                        .iter()
-                                        .find(|(_, info)| info.name == *name)
-                                        .map(|(output, _)| output.clone()),
+                                    OutputOption::OutputName(name) => {
+                                        window_state.output_by_name(&name)
+                                    }
                                     OutputOption::Active => None,
                                     OutputOption::LastOutput => window_state.last_output(),
                                 };
@@ -3072,11 +2940,9 @@ impl<T: 'static> WindowState<T> {
                             )) => {
                                 let output = match output_type {
                                     OutputOption::Output(output) => Some(output),
-                                    OutputOption::OutputName(name) => window_state
-                                        .xdg_info_cache
-                                        .iter()
-                                        .find(|(_, info)| info.name == *name)
-                                        .map(|(output, _)| output.clone()),
+                                    OutputOption::OutputName(name) => {
+                                        window_state.output_by_name(&name)
+                                    }
                                     OutputOption::Active => None,
                                     OutputOption::LastOutput => window_state.last_output(),
                                 };

--- a/iced_exwlshell/src/event.rs
+++ b/iced_exwlshell/src/event.rs
@@ -7,6 +7,8 @@ use iced_runtime::Action;
 
 use iced_core::keyboard::Modifiers as IcedModifiers;
 
+use crate::output::OutputInfo;
+
 fn from_u32_to_icedmouse(code: u32) -> mouse::Button {
     match code {
         273 => mouse::Button::Right,
@@ -99,6 +101,7 @@ pub enum WindowEvent {
     Refresh,
     Closed,
     ThemeChanged(iced_core::theme::Mode),
+    OutputChanged(Option<OutputInfo>),
 }
 
 #[derive(Debug)]
@@ -198,6 +201,7 @@ impl From<&DispatchMessage> for WindowEvent {
                 }
             }
             DispatchMessage::Ime(ime) => WindowEvent::Ime(ime.clone()),
+            DispatchMessage::OutputChanged(_) => WindowEvent::OutputChanged(None),
         }
     }
 }

--- a/iced_exwlshell/src/lib.rs
+++ b/iced_exwlshell/src/lib.rs
@@ -6,6 +6,7 @@ mod conversion;
 mod error;
 mod event;
 mod multi_window;
+pub mod output;
 mod proxy;
 mod user_interface;
 

--- a/iced_exwlshell/src/multi_window.rs
+++ b/iced_exwlshell/src/multi_window.rs
@@ -12,12 +12,13 @@ use crate::{
 };
 use crate::{
     event::{IcedWlShellEvent, WindowEvent as LayerShellWindowEvent},
+    output::{OutputEvent, OutputInfo},
     proxy::IcedProxy,
     settings::Settings,
 };
 use exwlshellev::{
-    DisplayWrapper, ExWlShellEvent, NewPopUpSettings, PopupPlacement, RefreshRequest, ReturnData,
-    WindowState, WindowWrapper,
+    DispatchMessage, DisplayWrapper, ExWlShellEvent, NewPopUpSettings, PopupPlacement,
+    RefreshRequest, ReturnData, WindowState, WindowWrapper,
     id::Id as LayerShellId,
     reexport::{
         wayland_client::{WlCompositor, WlRegion},
@@ -200,10 +201,16 @@ where
                 }
             }
             ExWlShellEvent::RequestMessages(message) => {
-                waiting_layer_shell_events.push_back((
-                    layer_shell_id,
-                    IcedWlShellEvent::Window(LayerShellWindowEvent::from(message)),
-                ));
+                let window_event = match message {
+                    DispatchMessage::OutputChanged(_) => LayerShellWindowEvent::OutputChanged(
+                        layer_shell_id
+                            .and_then(|id| ev.get_output_info(id))
+                            .map(OutputInfo::from),
+                    ),
+                    message => LayerShellWindowEvent::from(message),
+                };
+                waiting_layer_shell_events
+                    .push_back((layer_shell_id, IcedWlShellEvent::Window(window_event)));
             }
             ExWlShellEvent::UserEvent(event) => {
                 waiting_layer_shell_events
@@ -635,6 +642,7 @@ where
         self.cached_layer_dimensions.remove(&iced_id);
         self.window_manager.remove(iced_id);
         self.user_interfaces.remove(&iced_id);
+        crate::output::forget(iced_id);
         self.runtime
             .broadcast(iced_futures::subscription::Event::Interaction {
                 window: iced_id,
@@ -660,6 +668,12 @@ where
         let Some((iced_id, window)) = id_and_window else {
             return;
         };
+        if let LayerShellWindowEvent::OutputChanged(output) = &event {
+            crate::output::broadcast(OutputEvent {
+                window: iced_id,
+                output: output.clone(),
+            });
+        }
         // In previous implementation, event without layer_shell_id won't call `update` here, but
         // will broadcast to the application. I'm not sure why, but I think it is
         // reasonable to call `update` here.

--- a/iced_exwlshell/src/output.rs
+++ b/iced_exwlshell/src/output.rs
@@ -1,0 +1,85 @@
+use futures::channel::mpsc;
+use iced_core::{Point, Size, window::Id};
+use iced_futures::Subscription;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// output where surface is displayed
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputInfo {
+    /// output name, like `HDMI-A-1`
+    pub name: String,
+    /// human readable output description
+    pub description: String,
+    /// global output pos
+    pub logical_position: Point<i32>,
+    /// output size
+    pub logical_size: Size<i32>,
+}
+
+impl From<exwlshellev::OutputInfo> for OutputInfo {
+    fn from(info: exwlshellev::OutputInfo) -> Self {
+        Self {
+            name: info.name.unwrap_or_default(),
+            description: info.description.unwrap_or_default(),
+            logical_position: info.logical_position.map(Point::from).unwrap_or_default(),
+            logical_size: info.logical_size.map(Size::from).unwrap_or_default(),
+        }
+    }
+}
+
+/// window started being displayed on a different output
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputEvent {
+    /// moved window id
+    pub window: Id,
+    /// new output
+    pub output: Option<OutputInfo>,
+}
+
+#[derive(Default)]
+struct Registry {
+    subscribers: Vec<mpsc::UnboundedSender<OutputEvent>>,
+    /// last known output per window, replayed to new subscribers
+    last: HashMap<Id, Option<OutputInfo>>,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(Default::default)
+}
+
+/// deliver to every subscriber, dropping those whose receiver has gone away
+pub(crate) fn broadcast(event: OutputEvent) {
+    let Ok(mut registry) = registry().lock() else {
+        return;
+    };
+    registry.last.insert(event.window, event.output.clone());
+    registry
+        .subscribers
+        .retain(|sender| sender.unbounded_send(event.clone()).is_ok());
+}
+
+/// forget a closed window so it is not replayed to new subscribers
+pub(crate) fn forget(window: Id) {
+    if let Ok(mut registry) = registry().lock() {
+        registry.last.remove(&window);
+    }
+}
+
+/// listen for the output each window is displayed on
+pub fn listen() -> Subscription<OutputEvent> {
+    Subscription::run(|| {
+        let (sender, receiver) = mpsc::unbounded();
+        if let Ok(mut registry) = registry().lock() {
+            for (window, output) in &registry.last {
+                let _ = sender.unbounded_send(OutputEvent {
+                    window: *window,
+                    output: output.clone(),
+                });
+            }
+            registry.subscribers.push(sender);
+        }
+        receiver
+    })
+}

--- a/iced_exwlshell/tests/test_macro.rs
+++ b/iced_exwlshell/tests/test_macro.rs
@@ -9,7 +9,7 @@ fn test_layer_message_macro() {
     }
     let e = TestEnum::SizeChange {
         id: iced::window::Id::unique(),
-        size: ((1, 2)),
+        size: (1, 2),
     };
     let _ = e.clone();
 }

--- a/iced_layershell/src/event.rs
+++ b/iced_layershell/src/event.rs
@@ -7,6 +7,8 @@ use layershellev::xkb_keyboard::KeyEvent as LayerShellKeyEvent;
 
 use iced_core::keyboard::Modifiers as IcedModifiers;
 
+use crate::output::OutputInfo;
+
 fn from_u32_to_icedmouse(code: u32) -> mouse::Button {
     match code {
         273 => mouse::Button::Right,
@@ -99,6 +101,7 @@ pub enum WindowEvent {
     Refresh,
     Closed,
     ThemeChanged(iced_core::theme::Mode),
+    OutputChanged(Option<OutputInfo>),
 }
 
 #[derive(Debug)]
@@ -198,6 +201,7 @@ impl From<&DispatchMessage> for WindowEvent {
                 }
             }
             DispatchMessage::Ime(ime) => WindowEvent::Ime(ime.clone()),
+            DispatchMessage::OutputChanged(_) => WindowEvent::OutputChanged(None),
         }
     }
 }

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -6,6 +6,7 @@ mod conversion;
 mod error;
 mod event;
 mod multi_window;
+pub mod output;
 mod proxy;
 mod user_interface;
 

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use crate::{
     event::{IcedLayerShellEvent, WindowEvent as LayerShellWindowEvent},
+    output::{OutputEvent, OutputInfo},
     proxy::IcedProxy,
     settings::Settings,
 };
@@ -30,8 +31,8 @@ use iced_program::Program as IcedProgram;
 use iced_runtime::Action;
 use iced_runtime::user_interface;
 use layershellev::{
-    DisplayWrapper, LayerShellEvent, NewPopUpSettings, PopupPlacement, RefreshRequest, ReturnData,
-    WindowState, WindowWrapper,
+    DispatchMessage, DisplayWrapper, LayerShellEvent, NewPopUpSettings, PopupPlacement,
+    RefreshRequest, ReturnData, WindowState, WindowWrapper,
     id::Id as LayerShellId,
     reexport::{
         wayland_client::{WlCompositor, WlRegion},
@@ -200,10 +201,16 @@ where
                 }
             }
             LayerShellEvent::RequestMessages(message) => {
-                waiting_layer_shell_events.push_back((
-                    layer_shell_id,
-                    IcedLayerShellEvent::Window(LayerShellWindowEvent::from(message)),
-                ));
+                let window_event = match message {
+                    DispatchMessage::OutputChanged(_) => LayerShellWindowEvent::OutputChanged(
+                        layer_shell_id
+                            .and_then(|id| ev.get_output_info(id))
+                            .map(OutputInfo::from),
+                    ),
+                    message => LayerShellWindowEvent::from(message),
+                };
+                waiting_layer_shell_events
+                    .push_back((layer_shell_id, IcedLayerShellEvent::Window(window_event)));
             }
             LayerShellEvent::UserEvent(event) => {
                 waiting_layer_shell_events
@@ -614,6 +621,7 @@ where
         self.cached_layer_dimensions.remove(&iced_id);
         self.window_manager.remove(iced_id);
         self.user_interfaces.remove(&iced_id);
+        crate::output::forget(iced_id);
         self.runtime
             .broadcast(iced_futures::subscription::Event::Interaction {
                 window: iced_id,
@@ -639,6 +647,12 @@ where
         let Some((iced_id, window)) = id_and_window else {
             return;
         };
+        if let LayerShellWindowEvent::OutputChanged(output) = &event {
+            crate::output::broadcast(OutputEvent {
+                window: iced_id,
+                output: output.clone(),
+            });
+        }
         // In previous implementation, event without layer_shell_id won't call `update` here, but
         // will broadcast to the application. I'm not sure why, but I think it is
         // reasonable to call `update` here.

--- a/iced_layershell/src/output.rs
+++ b/iced_layershell/src/output.rs
@@ -1,0 +1,85 @@
+use futures::channel::mpsc;
+use iced_core::{Point, Size, window::Id};
+use iced_futures::Subscription;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// output where surface is displayed
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputInfo {
+    /// output name, like `HDMI-A-1`
+    pub name: String,
+    /// human readable output description
+    pub description: String,
+    /// global output pos
+    pub logical_position: Point<i32>,
+    /// output size
+    pub logical_size: Size<i32>,
+}
+
+impl From<layershellev::OutputInfo> for OutputInfo {
+    fn from(info: layershellev::OutputInfo) -> Self {
+        Self {
+            name: info.name.unwrap_or_default(),
+            description: info.description.unwrap_or_default(),
+            logical_position: info.logical_position.map(Point::from).unwrap_or_default(),
+            logical_size: info.logical_size.map(Size::from).unwrap_or_default(),
+        }
+    }
+}
+
+/// window started being displayed on a different output
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputEvent {
+    /// moved window id
+    pub window: Id,
+    /// new output
+    pub output: Option<OutputInfo>,
+}
+
+#[derive(Default)]
+struct Registry {
+    subscribers: Vec<mpsc::UnboundedSender<OutputEvent>>,
+    /// last known output per window, replayed to new subscribers
+    last: HashMap<Id, Option<OutputInfo>>,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(Default::default)
+}
+
+/// deliver to every subscriber, dropping those whose receiver has gone away
+pub(crate) fn broadcast(event: OutputEvent) {
+    let Ok(mut registry) = registry().lock() else {
+        return;
+    };
+    registry.last.insert(event.window, event.output.clone());
+    registry
+        .subscribers
+        .retain(|sender| sender.unbounded_send(event.clone()).is_ok());
+}
+
+/// forget a closed window so it is not replayed to new subscribers
+pub(crate) fn forget(window: Id) {
+    if let Ok(mut registry) = registry().lock() {
+        registry.last.remove(&window);
+    }
+}
+
+/// listen for the output each window is displayed on
+pub fn listen() -> Subscription<OutputEvent> {
+    Subscription::run(|| {
+        let (sender, receiver) = mpsc::unbounded();
+        if let Ok(mut registry) = registry().lock() {
+            for (window, output) in &registry.last {
+                let _ = sender.unbounded_send(OutputEvent {
+                    window: *window,
+                    output: output.clone(),
+                });
+            }
+            registry.subscribers.push(sender);
+        }
+        receiver
+    })
+}

--- a/layershellev/examples/simplelayer.rs
+++ b/layershellev/examples/simplelayer.rs
@@ -17,7 +17,7 @@ fn main() {
         .build()
         .unwrap();
 
-    ev.running(move |event, ev, index| {
+    ev.running(move |event, ev, _index| {
         match event {
             // NOTE: this will send when init, you can request bind extra object from here
             LayerShellEvent::InitRequest => ReturnData::RequestBind,
@@ -42,12 +42,6 @@ fn main() {
                     region.add(0, 0, 0, 0);
                     x.get_wlsurface().set_input_region(Some(&region));
                 }
-                ReturnData::None
-            }
-            LayerShellEvent::XdgInfoChanged(_) => {
-                let index = index.unwrap();
-                let unit = ev.get_unit_with_id(index).unwrap();
-                println!("{:?}", unit.get_xdgoutput_info());
                 ReturnData::None
             }
             LayerShellEvent::RequestBuffer(file, shm, qh, init_w, init_h) => {
@@ -83,6 +77,12 @@ fn main() {
                 surface_y,
             }) => {
                 println!("{time}, {surface_x}, {surface_y}");
+                ReturnData::None
+            }
+            LayerShellEvent::RequestMessages(DispatchMessage::OutputChanged(output)) => {
+                // NOTE: sent when surface enters another output, or its output info changes
+                let info = output.as_ref().and_then(|o| ev.get_output_info_of(o));
+                println!("{info:?}");
                 ReturnData::None
             }
             LayerShellEvent::RequestMessages(DispatchMessage::KeyboardInput { event, .. }) => {

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -46,8 +46,6 @@ pub enum LayerShellEvent<'a, T, Message> {
     /// [ReturnData::RequestBind], then it will continue to the next request.
     /// Here only the above two [ReturnData] are acceptable.
     InitRequest,
-    /// if the info of the XdgOutput is changed, it will send the event
-    XdgInfoChanged(XdgInfoChangedType),
     /// After you return [ReturnData::RequestBind] in the [LayerShellEvent::InitRequest] stage, next
     /// event is [LayerShellEvent::BindProvide], you can use the GlobalList and QueueHandle to create
     /// new wayland objects.
@@ -203,15 +201,6 @@ pub enum ReturnData<INFO> {
     None,
 }
 
-/// this tell the what kind of information passed by [LayerShellEvent::XdgInfoChanged]
-#[derive(Debug, Clone, Copy)]
-pub enum XdgInfoChangedType {
-    Position,
-    Size,
-    Name,
-    Description,
-}
-
 /// Describes a scroll along one axis
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct AxisScroll {
@@ -337,7 +326,7 @@ pub(crate) enum DispatchMessageInner {
         scale_u32: u32,
         scale_float: f64,
     },
-    XdgInfoChanged(XdgInfoChangedType),
+    OutputChanged(Option<WlOutput>),
     Ime(Ime),
 }
 
@@ -436,6 +425,8 @@ pub enum DispatchMessage {
         scale_float: f64,
     },
     Ime(Ime),
+    /// surface entered output, or left the one it was on
+    OutputChanged(Option<WlOutput>),
     Closed,
 }
 
@@ -540,7 +531,7 @@ impl From<DispatchMessageInner> for DispatchMessage {
                 scale_float,
             },
             DispatchMessageInner::Ime(ime) => DispatchMessage::Ime(ime),
-            DispatchMessageInner::XdgInfoChanged(_) => unimplemented!(),
+            DispatchMessageInner::OutputChanged(output) => DispatchMessage::OutputChanged(output),
         }
     }
 }

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -38,12 +38,6 @@
 //!                 println!("{:?}", virtual_keyboard_manager);
 //!                 ReturnData::None
 //!             }
-//!             LayerShellEvent::XdgInfoChanged(_) => {
-//!                 let index = index.unwrap();
-//!                 let unit = ev.get_unit_with_id(index).unwrap();
-//!                 println!("{:?}", unit.get_xdgoutput_info());
-//!                 ReturnData::None
-//!             }
 //!             LayerShellEvent::RequestBuffer(file, shm, qh, init_w, init_h) => {
 //!                 draw(file, (init_w, init_h));
 //!                 let pool = shm.create_pool(file.as_fd(), (init_w * init_h * 4) as i32, qh, ());
@@ -112,6 +106,7 @@ pub use events::NewLayerShellSettings;
 pub use events::NewXdgWindowSettings;
 pub use events::OutputOption;
 pub use events::{NewPopUpSettings, PopupPlacement};
+pub use sctk::output::OutputInfo;
 pub use waycrate_xkbkeycode::keyboard;
 pub use waycrate_xkbkeycode::xkb_keyboard;
 
@@ -123,9 +118,7 @@ use events::DispatchMessageInner;
 
 pub mod id;
 
-pub use events::{
-    AxisScroll, DispatchMessage, Ime, LayerShellEvent, ReturnData, XdgInfoChangedType,
-};
+pub use events::{AxisScroll, DispatchMessage, Ime, LayerShellEvent, ReturnData};
 
 use strtoshape::str_to_shape;
 
@@ -174,15 +167,9 @@ use wayland_protocols::xdg::shell::client::{
     xdg_wm_base::{self, XdgWmBase},
 };
 
-use wayland_protocols::{
-    wp::fractional_scale::v1::client::{
-        wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1,
-        wp_fractional_scale_v1::{self, WpFractionalScaleV1},
-    },
-    xdg::xdg_output::zv1::client::{
-        zxdg_output_manager_v1::ZxdgOutputManagerV1,
-        zxdg_output_v1::{self, ZxdgOutputV1},
-    },
+use wayland_protocols::wp::fractional_scale::v1::client::{
+    wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1,
+    wp_fractional_scale_v1::{self, WpFractionalScaleV1},
 };
 
 use wayland_protocols::wp::input_method::zv1::client::{
@@ -293,38 +280,6 @@ pub mod reexport {
     }
     pub mod wp_viewport {
         pub use wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
-    }
-}
-
-/// this struct store the xdg_output information
-#[derive(Debug, Clone)]
-pub struct ZxdgOutputInfo {
-    name: String,
-    description: String,
-    zxdgoutput: ZxdgOutputV1,
-    logical_size: (i32, i32),
-    position: (i32, i32),
-}
-
-impl ZxdgOutputInfo {
-    fn new(zxdgoutput: ZxdgOutputV1) -> Self {
-        Self {
-            zxdgoutput,
-            name: "".to_owned(),
-            description: "".to_owned(),
-            logical_size: (0, 0),
-            position: (0, 0),
-        }
-    }
-
-    /// you can get the Logic position of the screen current surface in
-    pub fn get_position(&self) -> (i32, i32) {
-        self.position
-    }
-
-    /// you can get the LogicalPosition of the screen current surface in
-    pub fn get_logical_size(&self) -> (i32, i32) {
-        self.logical_size
     }
 }
 
@@ -441,7 +396,6 @@ impl<T> WindowStateUnitBuilder<T> {
                 parent: None,
                 size: (0, 0),
                 buffer: Default::default(),
-                zxdgoutput: Default::default(),
                 fractional_scale: Default::default(),
                 viewport: Default::default(),
                 wl_output: Default::default(),
@@ -462,11 +416,6 @@ impl<T> WindowStateUnitBuilder<T> {
 
     fn size(mut self, size: (u32, u32)) -> Self {
         self.inner.size = size;
-        self
-    }
-
-    fn zxdgoutput(mut self, zxdgoutput: Option<ZxdgOutputInfo>) -> Self {
-        self.inner.zxdgoutput = zxdgoutput;
         self
     }
 
@@ -532,7 +481,6 @@ pub struct WindowStateUnit<T> {
     buffer: Option<WlBuffer>,
     shell: Shell,
     parent: Option<id::Id>,
-    zxdgoutput: Option<ZxdgOutputInfo>,
     fractional_scale: Option<WpFractionalScaleV1>,
     viewport: Option<WpViewport>,
     wl_output: Option<WlOutput>,
@@ -644,9 +592,9 @@ impl<T> WindowStateUnit<T> {
         &self.wl_surface
     }
 
-    /// get the xdg_output info related to this unit
-    pub fn get_xdgoutput_info(&self) -> Option<&ZxdgOutputInfo> {
-        self.zxdgoutput.as_ref()
+    /// output this surface is displayed on from compositor through `wl_surface::enter`
+    pub fn get_wloutput(&self) -> Option<&WlOutput> {
+        self.wl_output.as_ref()
     }
 
     /// set the anchor of the current unit. please take the simple.rs as reference
@@ -919,7 +867,6 @@ pub struct WindowState<T> {
     connection: Option<Connection>,
     event_queue: Option<EventQueue<WindowState<T>>>,
     wl_compositor: Option<WlCompositor>,
-    xdg_output_manager: Option<ZxdgOutputManagerV1>,
     wmbase: Option<XdgWmBase>,
     shm: Option<WlShm>,
     cursor_manager: Option<WpCursorShapeManagerV1>,
@@ -965,8 +912,6 @@ pub struct WindowState<T> {
     finger_locations: HashMap<i32, (f64, f64)>,
     enter_serial: Option<u32>,
     button_serial: Option<u32>,
-
-    xdg_info_cache: Vec<(wl_output::WlOutput, ZxdgOutputInfo)>,
 
     start_mode: StartMode,
     init_finished: bool,
@@ -1476,7 +1421,6 @@ impl<T> Default for WindowState<T> {
             wmbase: None,
             cursor_manager: None,
             viewporter: None,
-            xdg_output_manager: None,
             globals: None,
             fractional_scale_manager: None,
             virtual_keyboard: None,
@@ -1509,9 +1453,6 @@ impl<T> Default for WindowState<T> {
             finger_locations: HashMap::new(),
             enter_serial: None,
             button_serial: None,
-            // NOTE: if is some, means it is to be binded, but not now it
-            // is not binded
-            xdg_info_cache: Vec::new(),
 
             start_mode: StartMode::Active,
             init_finished: false,
@@ -1555,6 +1496,36 @@ impl<T> WindowState<T> {
     /// it return the iter of units. you can do loop with it
     pub fn get_unit_iter(&self) -> impl Iterator<Item = &WindowStateUnit<T>> {
         self.units.iter()
+    }
+
+    /// every output the compositor advertises with its info
+    pub fn outputs(&self) -> Vec<(WlOutput, OutputInfo)> {
+        let Some(state) = self.output_state.as_ref() else {
+            return Vec::new();
+        };
+        state
+            .outputs()
+            .filter_map(|output| state.info(&output).map(|info| (output, info)))
+            .collect()
+    }
+
+    /// the info of a given output, if it is still known.
+    pub fn get_output_info_of(&self, output: &WlOutput) -> Option<OutputInfo> {
+        self.output_state.as_ref()?.info(output)
+    }
+
+    /// the output matching `name` (`HDMI-A-1` and such), if it is connected.
+    pub fn output_by_name(&self, name: &str) -> Option<WlOutput> {
+        let state = self.output_state.as_ref()?;
+        state
+            .outputs()
+            .find(|output| state.info(output).and_then(|info| info.name).as_deref() == Some(name))
+    }
+
+    /// the output info the surface `id` is currently displayed on
+    pub fn get_output_info(&self, id: id::Id) -> Option<OutputInfo> {
+        let output = self.get_unit_with_id(id)?.wl_output.clone()?;
+        self.get_output_info_of(&output)
     }
 
     /// get the current focused surface id
@@ -1657,8 +1628,20 @@ impl<T: 'static> OutputHandler for WindowState<T> {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _output: wl_output::WlOutput,
+        output: wl_output::WlOutput,
     ) {
+        let affected: Vec<id::Id> = self
+            .units
+            .iter()
+            .filter(|unit| unit.wl_output.as_ref() == Some(&output))
+            .map(|unit| unit.id)
+            .collect();
+        for id in affected {
+            self.message.push((
+                Some(id),
+                DispatchMessageInner::OutputChanged(Some(output.clone())),
+            ));
+        }
     }
     fn output_destroyed(
         &mut self,
@@ -1673,11 +1656,7 @@ impl<T: 'static> OutputHandler for WindowState<T> {
         {
             self.last_wloutput.take();
         }
-        let outputs_removed = self.outputs.extract_if(.., |o| o == &output);
-        for output_removed in outputs_removed {
-            self.xdg_info_cache
-                .retain(|info| info.0.id() != output_removed.id());
-        }
+        self.outputs.retain(|o| o != &output);
 
         let removed_states = self.units.extract_if(.., |unit| {
             !unit.wl_surface.is_alive()
@@ -1811,74 +1790,6 @@ impl<T> Dispatch<xdg_popup::XdgPopup, ()> for WindowState<T> {
     }
 }
 
-impl<T> Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for WindowState<T> {
-    fn event(
-        state: &mut Self,
-        proxy: &zxdg_output_v1::ZxdgOutputV1,
-        event: <zxdg_output_v1::ZxdgOutputV1 as Proxy>::Event,
-        _data: &(),
-        _conn: &Connection,
-        _qhandle: &QueueHandle<Self>,
-    ) {
-        if let Some((_, xdg_info)) = state
-            .xdg_info_cache
-            .iter_mut()
-            .find(|(_, info)| info.zxdgoutput == *proxy)
-        {
-            match event {
-                zxdg_output_v1::Event::LogicalSize { width, height } => {
-                    xdg_info.logical_size = (width, height);
-                }
-                zxdg_output_v1::Event::LogicalPosition { x, y } => {
-                    xdg_info.position = (x, y);
-                }
-                zxdg_output_v1::Event::Name { ref name } => {
-                    xdg_info.name = name.clone();
-                }
-                zxdg_output_v1::Event::Description { ref description } => {
-                    xdg_info.description = description.clone();
-                }
-                _ => {}
-            };
-        }
-
-        let Some(index) = state.units.iter().position(|info| {
-            info.zxdgoutput
-                .as_ref()
-                .is_some_and(|zxdgoutput| zxdgoutput.zxdgoutput == *proxy)
-        }) else {
-            return;
-        };
-        let info = &mut state.units[index];
-        let xdg_info = info.zxdgoutput.as_mut().unwrap();
-        let change_type = match event {
-            zxdg_output_v1::Event::LogicalSize { width, height } => {
-                xdg_info.logical_size = (width, height);
-                XdgInfoChangedType::Size
-            }
-            zxdg_output_v1::Event::LogicalPosition { x, y } => {
-                xdg_info.position = (x, y);
-                XdgInfoChangedType::Position
-            }
-            zxdg_output_v1::Event::Name { name } => {
-                xdg_info.name = name;
-                XdgInfoChangedType::Name
-            }
-            zxdg_output_v1::Event::Description { description } => {
-                xdg_info.description = description;
-                XdgInfoChangedType::Description
-            }
-            _ => {
-                return;
-            }
-        };
-        state.message.push((
-            Some(state.units[index].id),
-            DispatchMessageInner::XdgInfoChanged(change_type),
-        ));
-    }
-}
-
 impl<T> Dispatch<wp_fractional_scale_v1::WpFractionalScaleV1, ()> for WindowState<T> {
     fn event(
         state: &mut Self,
@@ -1924,9 +1835,11 @@ impl<T> Dispatch<WlSurface, ()> for WindowState<T> {
         else {
             return;
         };
-        match event {
+        let id = unit.id;
+        let changed = match event {
             wl_surface::Event::Enter { output } => {
-                unit.wl_output.replace(output);
+                let previous = unit.wl_output.replace(output);
+                previous.as_ref() != unit.wl_output.as_ref()
             }
             wl_surface::Event::Leave { output }
                 if !matches!(unit.shell, Shell::LayerShell(..))
@@ -1936,8 +1849,15 @@ impl<T> Dispatch<WlSurface, ()> for WindowState<T> {
                         .is_some_and(|i_output| i_output == &output) =>
             {
                 unit.wl_output.take();
+                true
             }
-            _ => {}
+            _ => false,
+        };
+        if changed {
+            let output = unit.wl_output.clone();
+            state
+                .message
+                .push((Some(id), DispatchMessageInner::OutputChanged(output)));
         }
     }
 }
@@ -2110,7 +2030,6 @@ delegate_noop!(@<T> WindowState<T>: ignore WpViewport);
 delegate_noop!(@<T> WindowState<T>: ignore ZwpVirtualKeyboardV1);
 delegate_noop!(@<T> WindowState<T>: ignore ZwpVirtualKeyboardManagerV1);
 
-delegate_noop!(@<T> WindowState<T>: ignore ZxdgOutputManagerV1);
 delegate_noop!(@<T> WindowState<T>: ignore WpFractionalScaleManagerV1);
 delegate_noop!(@<T> WindowState<T>: ignore XdgPositioner);
 sctk::delegate_registry!(@<T: 'static> WindowState<T>);
@@ -2178,9 +2097,6 @@ impl<T: 'static> WindowState<T> {
 
         // register this
 
-        let xdg_output_manager = globals.bind::<ZxdgOutputManagerV1, _, _>(&qh, 1..=3, ())?; // bind
-        // xdg_output_manager
-
         let decoration_manager = globals
             .bind::<ZxdgDecorationManagerV1, _, _>(&qh, 1..=1, ())
             .ok();
@@ -2197,17 +2113,11 @@ impl<T: 'static> WindowState<T> {
         self.text_input_manager = text_input_manager;
         event_queue.blocking_dispatch(&mut self)?; // then make a dispatch
 
-        // do the step before, you get empty list
-
-        for output_display in &self.outputs {
-            let zxdgoutput = xdg_output_manager.get_xdg_output(output_display, &qh, ());
-            self.xdg_info_cache
-                .push((output_display.clone(), ZxdgOutputInfo::new(zxdgoutput)));
-        }
-        event_queue.blocking_dispatch(&mut self)?; // then make a dispatch
-        // so it is the same way, to get surface detach to protocol, first get the shell, like wmbase
-        // or layer_shell or session-shell, then get `surface` from the wl_surface you get before, and
-        // set it
+        // OutputState bound its own xdg_outputs before the dispatch above, so output info is
+        // populated by now, a second roundtrip is not needed
+        // so it is the same way, to get surface detach to protocol, first get the shell, like
+        // wmbase or layer_shell or session-shell, then get `surface` from the wl_surface you
+        // get before, and set it
         // finally thing to remember is to commit the surface, make the shell to init.
         //let (init_w, init_h) = self.size;
         // this example is ok for both xdg_surface and layer_shell
@@ -2220,24 +2130,10 @@ impl<T: 'static> WindowState<T> {
             }
             self.background_surface = Some(background_surface);
         } else if !self.is_allscreens() {
-            let mut output = None;
-
-            let (binded_output, binded_xdginfo) = match self.start_mode.clone() {
-                StartMode::TargetScreen(name) => {
-                    if let Some(cache) = self
-                        .xdg_info_cache
-                        .iter()
-                        .find(|(_, info)| info.name == *name)
-                        .cloned()
-                    {
-                        output = Some(cache.clone());
-                    }
-                    let binded_output = output.as_ref().map(|(output, _)| output).cloned();
-                    let binded_xdginfo = output.as_ref().map(|(_, xdginfo)| xdginfo).cloned();
-                    (binded_output, binded_xdginfo)
-                }
-                StartMode::TargetOutput(output) => (Some(output), None),
-                _ => (None, None),
+            let binded_output = match self.start_mode.clone() {
+                StartMode::TargetScreen(name) => self.output_by_name(&name),
+                StartMode::TargetOutput(output) => Some(output),
+                _ => None,
             };
 
             let wl_surface = wmcompositer.create_surface(&qh, ()); // and create a surface. if two or more,
@@ -2295,7 +2191,6 @@ impl<T: 'static> WindowState<T> {
                     Shell::LayerShell(layer),
                 )
                 .viewport(viewport)
-                .zxdgoutput(binded_xdginfo)
                 .fractional_scale(fractional_scale)
                 .wl_output(binded_output.clone())
                 .build(),
@@ -2336,7 +2231,6 @@ impl<T: 'static> WindowState<T> {
                 }
                 wl_surface.commit();
 
-                let zxdgoutput = xdg_output_manager.get_xdg_output(output_display, &qh, ());
                 let mut fractional_scale = None;
                 if let Some(ref fractional_scale_manager) = fractional_scale_manager {
                     fractional_scale =
@@ -2359,7 +2253,6 @@ impl<T: 'static> WindowState<T> {
                         Shell::LayerShell(layer),
                     )
                     .viewport(viewport)
-                    .zxdgoutput(Some(ZxdgOutputInfo::new(zxdgoutput)))
                     .fractional_scale(fractional_scale)
                     .wl_output(Some(output_display.clone()))
                     .build(),
@@ -2374,7 +2267,6 @@ impl<T: 'static> WindowState<T> {
         self.wl_compositor = Some(wmcompositer);
         self.fractional_scale_manager = fractional_scale_manager;
         self.cursor_manager = cursor_manager;
-        self.xdg_output_manager = Some(xdg_output_manager);
         self.connection = Some(connection);
 
         Ok(self)
@@ -2428,7 +2320,6 @@ impl<T: 'static> WindowState<T> {
         let shm = self.shm.take().unwrap();
         let fractional_scale_manager = self.fractional_scale_manager.take();
         let cursor_manager: Option<WpCursorShapeManagerV1> = self.cursor_manager.take();
-        let xdg_output_manager = self.xdg_output_manager.take().unwrap();
         let connection = self.connection.take().unwrap();
         let mut init_event = None;
         let wmbase = self.wmbase.take().unwrap();
@@ -2491,20 +2382,7 @@ impl<T: 'static> WindowState<T> {
             std::mem::swap(&mut messages, &mut window_state.message);
             for msg in messages.iter() {
                 match msg {
-                    (index_info, DispatchMessageInner::XdgInfoChanged(change_type)) => {
-                        window_state.handle_event(
-                            &mut *event_handler,
-                            LayerShellEvent::XdgInfoChanged(*change_type),
-                            *index_info,
-                        );
-                    }
                     (_, DispatchMessageInner::NewDisplay(output_display)) => {
-                        let zxdgoutput = xdg_output_manager.get_xdg_output(output_display, &qh, ());
-
-                        window_state.xdg_info_cache.push((
-                            output_display.clone(),
-                            ZxdgOutputInfo::new(zxdgoutput.clone()),
-                        ));
                         if !window_state.is_allscreens() {
                             continue;
                         }
@@ -2562,7 +2440,6 @@ impl<T: 'static> WindowState<T> {
                                 Shell::LayerShell(layer),
                             )
                             .viewport(viewport)
-                            .zxdgoutput(Some(ZxdgOutputInfo::new(zxdgoutput)))
                             .fractional_scale(fractional_scale)
                             .wl_output(Some(output_display.clone()))
                             .build(),
@@ -2615,11 +2492,9 @@ impl<T: 'static> WindowState<T> {
                         )) => {
                             let output = match output_type {
                                 OutputOption::Output(output) => Some(output),
-                                OutputOption::OutputName(name) => window_state
-                                    .xdg_info_cache
-                                    .iter()
-                                    .find(|(_, info)| info.name == *name)
-                                    .map(|(output, _)| output.clone()),
+                                OutputOption::OutputName(name) => {
+                                    window_state.output_by_name(&name)
+                                }
                                 OutputOption::Active => None,
                                 OutputOption::LastOutput => window_state.last_output(),
                             };
@@ -2877,11 +2752,9 @@ impl<T: 'static> WindowState<T> {
                         )) => {
                             let output = match output_type {
                                 OutputOption::Output(output) => Some(output),
-                                OutputOption::OutputName(name) => window_state
-                                    .xdg_info_cache
-                                    .iter()
-                                    .find(|(_, info)| info.name == *name)
-                                    .map(|(output, _)| output.clone()),
+                                OutputOption::OutputName(name) => {
+                                    window_state.output_by_name(&name)
+                                }
                                 OutputOption::Active => None,
                                 OutputOption::LastOutput => window_state.last_output(),
                             };


### PR DESCRIPTION
done:

- Replace manual zxdg with sctk's `OutputState` (breaking: removes `XdgInfoChanged`, `XdgInfoChangedType`, `ZxdgOutputInfo`, `get_xdgoutput_info()`)
- new `DispatchMessage::OutputChanged` sent when a surface enters another output or info changes
- new fns under `WindowState`: `outputs()`, `output_by_name()`, `get_output_info()`, `get_output_info_of()`, `WindowStateUnit::get_wloutput()`
- new `output::listen()` subscription to track on what output window is displayed

Why/How discovered issues:
wanted to have multi-surface widgets that have weird spawn timings and initially spawn via `Active`, but other surfaces need to inherit output from first widget without depending on mouse pos.