### PR TITLE
feat: init guards for zero values

### DIFF
--- a/exwlshellev/examples/simpleshell.rs
+++ b/exwlshellev/examples/simpleshell.rs
@@ -8,7 +8,7 @@ use exwlshellev::*;
 fn main() {
     let ev: WindowState<()> = WindowState::new("Hello")
         .with_allscreens()
-        .with_size((0, 400))
+        .with_size(LayerSize::fill_width(400))
         .with_layer(Layer::Top)
         .with_margin((20, 20, 100, 20))
         .with_anchor(Anchor::Bottom | Anchor::Left | Anchor::Right)

--- a/exwlshellev/src/events.rs
+++ b/exwlshellev/src/events.rs
@@ -20,6 +20,8 @@ use wayland_client::{
     },
 };
 
+use crate::size::{LayerSize, PixelSize};
+
 use crate::{blur::BlurOption, id, xkb_keyboard::KeyEvent};
 
 use crate::keyboard::ModifiersState;
@@ -91,8 +93,8 @@ pub enum OutputOption {
 /// layershell settings to create a new layershell surface
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewLayerShellSettings {
-    /// the size of the layershell, optional.
-    pub size: Option<(u32, u32)>,
+    /// the size of the layershell
+    pub size: LayerSize,
     pub layer: Layer,
     pub anchor: Anchor,
     pub exclusive_zone: Option<i32>,
@@ -110,8 +112,13 @@ pub struct NewLayerShellSettings {
 /// How a popup is positioned relative to its parent surface.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PopupPlacement {
-    /// anchor rectangle in the parent surface's local coordinates (x, y, w, h)
-    Anchored((i32, i32, i32, i32)),
+    /// anchor rectangle in the parent surface's local coordinates
+    Anchored {
+        /// the top-left corner of the anchor rectangle
+        position: (i32, i32),
+        /// the extents of the anchor rectangle
+        size: PixelSize,
+    },
     /// Absolute position of the popup in the parent surface's local coordinates
     Position((i32, i32)),
 }
@@ -120,7 +127,7 @@ pub enum PopupPlacement {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct NewPopUpSettings {
     /// the size of the popup
-    pub size: (u32, u32),
+    pub size: PixelSize,
     /// the id of the parent surface
     pub id: id::Id,
     /// How a popup is positioned relative to its parent surface.
@@ -140,7 +147,7 @@ pub struct NewXdgWindowSettings {
     /// The window title.
     pub title: Option<String>,
     /// The initial window size.
-    pub size: Option<(u32, u32)>,
+    pub size: Option<PixelSize>,
     /// Request client-side decorations instead of the default server-side mode.
     pub client_side_decorations: bool,
 }
@@ -148,7 +155,7 @@ pub struct NewXdgWindowSettings {
 /// input panel settings to create a new input panel surface
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewInputPanelSettings {
-    pub size: (u32, u32),
+    pub size: PixelSize,
     /// set the surface type as a keyboard
     pub keyboard: bool,
     /// follow the last output of the activated surface, used to create some thing like mako, who
@@ -160,10 +167,10 @@ pub struct NewInputPanelSettings {
 impl Default for NewLayerShellSettings {
     fn default() -> Self {
         NewLayerShellSettings {
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+            anchor: Anchor::all(),
             layer: Layer::Top,
             exclusive_zone: None,
-            size: None,
+            size: LayerSize::FILL,
             margin: Some((0, 0, 0, 0)),
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
             output_option: OutputOption::Active,

--- a/exwlshellev/src/lib.rs
+++ b/exwlshellev/src/lib.rs
@@ -13,7 +13,7 @@
 //! fn main() {
 //!     let mut ev: WindowState<()> = WindowState::new("Hello")
 //!         .with_allscreens()
-//!         .with_size((0, 400))
+//!         .with_size(LayerSize::fill_width(400))
 //!         .with_layer(Layer::Top)
 //!         .with_margin((20, 20, 100, 20))
 //!         .with_anchor(Anchor::Bottom | Anchor::Left | Anchor::Right)
@@ -113,9 +113,12 @@ pub mod blur;
 pub mod dpi;
 mod events;
 mod seat;
+mod size;
 mod strtoshape;
 
 use events::DispatchMessageInner;
+use size::warn_if_exclusive_zone_ignored;
+pub use size::{Extent, LayerSize, PixelSize};
 
 pub mod id;
 
@@ -430,6 +433,8 @@ impl<T> WindowStateUnitBuilder<T> {
                 shell,
                 parent: None,
                 size: (0, 0),
+                anchor: Anchor::empty(),
+                layer_size: LayerSize::FILL,
                 buffer: Default::default(),
                 fractional_scale: Default::default(),
                 viewport: Default::default(),
@@ -453,6 +458,12 @@ impl<T> WindowStateUnitBuilder<T> {
 
     fn size(mut self, size: (u32, u32)) -> Self {
         self.inner.size = size;
+        self
+    }
+
+    fn layout(mut self, anchor: Anchor, layer_size: LayerSize) -> Self {
+        self.inner.anchor = anchor;
+        self.inner.layer_size = layer_size;
         self
     }
 
@@ -526,6 +537,10 @@ pub struct WindowStateUnit<T> {
     wl_surface: WlSurface,
     wmcompositor: WlCompositor,
     size: (u32, u32),
+    /// Only meaningful for LayerShell
+    anchor: Anchor,
+    /// Only meaningful for LayerShell
+    layer_size: LayerSize,
     buffer: Option<WlBuffer>,
     shell: Shell,
     parent: Option<id::Id>,
@@ -569,6 +584,16 @@ impl<T> WindowStateUnit<T> {
 
     pub fn try_set_viewport_destination(&self, width: i32, height: i32) -> Option<()> {
         let viewport = self.viewport.as_ref()?;
+        // (-1, -1) unsets the destination
+        if (width, height) != (-1, -1) && (width <= 0 || height <= 0) {
+            log::warn!(
+                target: "layershellev",
+                "ignoring viewport destination {width}x{height} for {:?}: wp_viewport requires \
+                 positive dimensions, or (-1, -1) to unset",
+                self.id
+            );
+            return None;
+        }
         viewport.set_destination(width, height);
         Some(())
     }
@@ -700,12 +725,40 @@ impl<T> WindowStateUnit<T> {
         self.wl_output.as_ref()
     }
 
-    /// set the anchor of the current unit. please take the simple.rs as reference
-    pub fn set_anchor(&self, anchor: Anchor) {
-        if let Shell::LayerShell(layer_shell) = &self.shell {
-            layer_shell.set_anchor(anchor);
-            self.wl_surface.commit();
+    /// last requested anchor for surface
+    pub fn get_anchor(&self) -> Anchor {
+        self.anchor
+    }
+
+    /// actual layer surface anchor
+    pub fn get_effective_anchor(&self) -> Anchor {
+        if !matches!(self.shell, Shell::LayerShell(_)) {
+            return Anchor::empty();
         }
+        self.anchor | self.layer_size.missing_edges(self.anchor)
+    }
+
+    /// last requested size for surface
+    pub fn get_layer_size(&self) -> LayerSize {
+        self.layer_size
+    }
+
+    /// commit anchor and size, while adding required edges for size
+    fn commit_layout(&mut self, anchor: Anchor, size: LayerSize) {
+        let Shell::LayerShell(layer_shell) = &self.shell else {
+            return;
+        };
+        let (width, height) = size.to_set();
+        layer_shell.set_anchor(size.resolve_anchor(anchor));
+        layer_shell.set_size(width, height);
+        self.anchor = anchor;
+        self.layer_size = size;
+        self.wl_surface.commit();
+    }
+
+    /// set the anchor of the current unit. please take the simple.rs as reference
+    pub fn set_anchor(&mut self, anchor: Anchor) {
+        self.commit_layout(anchor, self.layer_size);
     }
 
     /// you can reset the margin which bind to the surface
@@ -725,26 +778,20 @@ impl<T> WindowStateUnit<T> {
     }
 
     /// set the anchor and set the size together
-    /// When you want to change layer from LEFT|RIGHT|BOTTOM to TOP|LEFT|BOTTOM, use it
-    pub fn set_anchor_with_size(&self, anchor: Anchor, (width, height): (u32, u32)) {
-        if let Shell::LayerShell(layer_shell) = &self.shell {
-            layer_shell.set_anchor(anchor);
-            layer_shell.set_size(width, height);
-            self.wl_surface.commit();
-        }
+    /// When you want to change the layout from LEFT|RIGHT|BOTTOM to TOP|LEFT|BOTTOM, use it.
+    pub fn set_layout(&mut self, anchor: Anchor, size: LayerSize) {
+        self.commit_layout(anchor, size);
     }
 
     /// set the layer size of current unit
-    pub fn set_size(&self, (width, height): (u32, u32)) {
-        if let Shell::LayerShell(layer_shell) = &self.shell {
-            layer_shell.set_size(width, height);
-            self.wl_surface.commit();
-        }
+    pub fn set_size(&mut self, size: LayerSize) {
+        self.commit_layout(self.anchor, size);
     }
 
     /// set current exclusive_zone
     pub fn set_exclusive_zone(&self, zone: i32) {
         if let Shell::LayerShell(layer_shell) = &self.shell {
+            warn_if_exclusive_zone_ignored(zone, self.get_effective_anchor());
             layer_shell.set_exclusive_zone(zone);
             self.wl_surface.commit();
         }
@@ -995,7 +1042,7 @@ pub struct WindowState<T> {
     keyboard_interactivity: zwlr_layer_surface_v1::KeyboardInteractivity,
     anchor: Anchor,
     layer: Layer,
-    size: Option<(u32, u32)>,
+    size: LayerSize,
     exclusive_zone: Option<i32>,
     margin: Option<(i32, i32, i32, i32)>,
     blur_option: BlurOption,
@@ -1474,17 +1521,11 @@ impl<T> WindowState<T> {
         self
     }
 
-    /// if not set, it will be the size suggested by layer_shell, like anchor to four ways,
-    /// and margins to 0,0,0,0 , the size will be the size of screen.
+    /// if not set, the default is [`LayerSize::FILL`], which with the default four-edge
+    /// anchor and margins to 0,0,0,0 gives a surface the size of the screen.
     ///
     /// if set, layer_shell will use the size you set
-    pub fn with_size(mut self, size: (u32, u32)) -> Self {
-        self.size = Some(size);
-        self
-    }
-
-    /// set the window size, optional
-    pub fn with_option_size(mut self, size: Option<(u32, u32)>) -> Self {
+    pub fn with_size(mut self, size: LayerSize) -> Self {
         self.size = size;
         self
     }
@@ -1545,7 +1586,7 @@ impl<T> Default for WindowState<T> {
             keyboard_interactivity: zwlr_layer_surface_v1::KeyboardInteractivity::OnDemand,
             layer: Layer::Overlay,
             anchor: Anchor::Top | Anchor::Left | Anchor::Right | Anchor::Bottom,
-            size: None,
+            size: LayerSize::FILL,
             exclusive_zone: None,
             margin: None,
             blur_option: BlurOption::None,
@@ -2290,13 +2331,14 @@ impl<T: 'static> WindowState<T> {
                 &qh,
                 (),
             );
-            layer.set_anchor(self.anchor);
+            let wire_anchor = self.size.resolve_anchor(self.anchor);
+            layer.set_anchor(wire_anchor);
             layer.set_keyboard_interactivity(self.keyboard_interactivity);
-            if let Some((init_w, init_h)) = self.size {
-                layer.set_size(init_w, init_h);
-            }
+            let (init_w, init_h) = self.size.to_set();
+            layer.set_size(init_w, init_h);
 
             if let Some(zone) = self.exclusive_zone {
+                warn_if_exclusive_zone_ignored(zone, wire_anchor);
                 layer.set_exclusive_zone(zone);
             }
 
@@ -2338,6 +2380,7 @@ impl<T: 'static> WindowState<T> {
                     Shell::LayerShell(layer),
                 )
                 .blur_option(self.blur_option.clone())
+                .layout(self.anchor, self.size)
                 .effect_surface(effect)
                 .viewport(viewport)
                 .fractional_scale(fractional_scale)
@@ -2359,13 +2402,14 @@ impl<T: 'static> WindowState<T> {
                     &qh,
                     (),
                 );
-                layer.set_anchor(self.anchor);
+                let wire_anchor = self.size.resolve_anchor(self.anchor);
+                layer.set_anchor(wire_anchor);
                 layer.set_keyboard_interactivity(self.keyboard_interactivity);
-                if let Some((init_w, init_h)) = self.size {
-                    layer.set_size(init_w, init_h);
-                }
+                let (init_w, init_h) = self.size.to_set();
+                layer.set_size(init_w, init_h);
 
                 if let Some(zone) = self.exclusive_zone {
+                    warn_if_exclusive_zone_ignored(zone, wire_anchor);
                     layer.set_exclusive_zone(zone);
                 }
 
@@ -2406,9 +2450,10 @@ impl<T: 'static> WindowState<T> {
                         wmcompositer.clone(),
                         Shell::LayerShell(layer),
                     )
+                    .layout(self.anchor, self.size)
+                    .viewport(viewport)
                     .blur_option(self.blur_option.clone())
                     .effect_surface(effect)
-                    .viewport(viewport)
                     .fractional_scale(fractional_scale)
                     .wl_output(Some(output_display.clone()))
                     .build(),
@@ -2582,6 +2627,7 @@ impl<T: 'static> WindowState<T> {
                                         wmcompositer.clone(),
                                         Shell::SessionLock(session_lock_surface),
                                     )
+                                    .layout(window_state.anchor, window_state.size)
                                     .viewport(viewport)
                                     .fractional_scale(fractional_scale)
                                     .wl_output(Some(output_display.clone()))
@@ -2604,10 +2650,15 @@ impl<T: 'static> WindowState<T> {
                                 &qh,
                                 (),
                             );
-                            layer.set_anchor(window_state.anchor);
+                            let wire_anchor = window_state.size.resolve_anchor(window_state.anchor);
+                            layer.set_anchor(wire_anchor);
                             layer.set_keyboard_interactivity(window_state.keyboard_interactivity);
-                            if let Some((init_w, init_h)) = window_state.size {
-                                layer.set_size(init_w, init_h);
+                            let (init_w, init_h) = window_state.size.to_set();
+                            layer.set_size(init_w, init_h);
+
+                            if let Some(zone) = window_state.exclusive_zone {
+                                warn_if_exclusive_zone_ignored(zone, wire_anchor);
+                                layer.set_exclusive_zone(zone);
                             }
 
                             if let Some(zone) = window_state.exclusive_zone {
@@ -2647,6 +2698,7 @@ impl<T: 'static> WindowState<T> {
                                     wmcompositer.clone(),
                                     Shell::LayerShell(layer),
                                 )
+                                .layout(window_state.anchor, window_state.size)
                                 .viewport(viewport)
                                 .fractional_scale(fractional_scale)
                                 .wl_output(Some(output_display.clone()))
@@ -2765,6 +2817,7 @@ impl<T: 'static> WindowState<T> {
                                 id,
                                 info,
                             )) => {
+                                let wire_anchor = size.resolve_anchor(anchor);
                                 let output = match output_type {
                                     OutputOption::Output(output) => Some(output),
                                     OutputOption::OutputName(name) => {
@@ -2787,13 +2840,13 @@ impl<T: 'static> WindowState<T> {
                                     &qh,
                                     (),
                                 );
-                                layer.set_anchor(anchor);
+                                layer.set_anchor(wire_anchor);
                                 layer.set_keyboard_interactivity(keyboard_interactivity);
-                                if let Some((init_w, init_h)) = size {
-                                    layer.set_size(init_w, init_h);
-                                }
+                                let (init_w, init_h) = size.to_set();
+                                layer.set_size(init_w, init_h);
 
                                 if let Some(zone) = exclusive_zone {
+                                    warn_if_exclusive_zone_ignored(zone, wire_anchor);
                                     layer.set_exclusive_zone(zone);
                                 }
 
@@ -2841,9 +2894,10 @@ impl<T: 'static> WindowState<T> {
                                         wmcompositer.clone(),
                                         Shell::LayerShell(layer),
                                     )
+                                    .layout(window_state.anchor, window_state.size)
+                                    .viewport(viewport)
                                     .blur_option(blur_option)
                                     .effect_surface(effect)
-                                    .viewport(viewport)
                                     .fractional_scale(fractional_scale)
                                     .wl_output(output)
                                     .binding(info)
@@ -2853,7 +2907,7 @@ impl<T: 'static> WindowState<T> {
                             }
                             ReturnData::NewPopUp((
                                 NewPopUpSettings {
-                                    size: (width, height),
+                                    size,
                                     id,
                                     placement,
                                     anchor,
@@ -2864,22 +2918,6 @@ impl<T: 'static> WindowState<T> {
                                 targetid,
                                 info,
                             )) => {
-                                if width == 0 || height == 0 {
-                                    log::warn!(
-                                        target: "exwlshellev",
-                                        "popup {targetid:?} size must be positive, got {width}x{height}; skipping popup creation"
-                                    );
-                                    continue;
-                                }
-                                if let PopupPlacement::Anchored((_, _, arw, arh)) = placement
-                                    && (arw < 0 || arh < 0)
-                                {
-                                    log::warn!(
-                                        target: "exwlshellev",
-                                        "popup {targetid:?} anchor_rect dimensions must be non-negative, got ({arw}, {arh}); skipping popup creation"
-                                    );
-                                    continue;
-                                }
                                 let Some(index) =
                                     window_state.units.iter().position(|unit| unit.id == id)
                                 else {
@@ -2887,14 +2925,19 @@ impl<T: 'static> WindowState<T> {
                                 };
                                 let wl_surface = wmcompositer.create_surface(&qh, ());
                                 let positioner = wmbase.create_positioner(&qh, ());
-                                positioner.set_size(width as i32, height as i32);
+                                let (width, height) = size.to_set_i32();
+                                positioner.set_size(width, height);
                                 // `Position` is a 1×1 anchor rect at the point;
                                 // `Anchored` uses the rect directly.
                                 match placement {
                                     PopupPlacement::Position((px, py)) => {
                                         positioner.set_anchor_rect(px, py, 1, 1)
                                     }
-                                    PopupPlacement::Anchored((arx, ary, arw, arh)) => {
+                                    PopupPlacement::Anchored {
+                                        position: (arx, ary),
+                                        size: rect,
+                                    } => {
+                                        let (arw, arh) = rect.to_set_i32();
                                         positioner.set_anchor_rect(arx, ary, arw, arh)
                                     }
                                 }
@@ -2961,7 +3004,7 @@ impl<T: 'static> WindowState<T> {
                                         Shell::PopUp((popup, wl_xdg_surface)),
                                     )
                                     .parent(Some(id))
-                                    .size((width, height))
+                                    .size(size.to_set())
                                     .viewport(viewport)
                                     .fractional_scale(fractional_scale)
                                     .binding(info)
@@ -3022,7 +3065,7 @@ impl<T: 'static> WindowState<T> {
                                         wmcompositer.clone(),
                                         Shell::XdgTopLevel((toplevel, wl_xdg_surface, decoration)),
                                     )
-                                    .size(size.unwrap_or((300, 300)))
+                                    .size(size.unwrap_or(PixelSize::px(300, 300)).to_set())
                                     .viewport(viewport)
                                     .fractional_scale(fractional_scale)
                                     .binding(info)
@@ -3033,7 +3076,7 @@ impl<T: 'static> WindowState<T> {
 
                             ReturnData::NewInputPanel((
                                 NewInputPanelSettings {
-                                    size: (width, height),
+                                    size,
                                     keyboard,
                                     output_option: output_type,
                                 },
@@ -3093,7 +3136,7 @@ impl<T: 'static> WindowState<T> {
                                         wmcompositer.clone(),
                                         Shell::InputPanel(input_panel_surface),
                                     )
-                                    .size((width, height))
+                                    .size(size.to_set())
                                     .viewport(viewport)
                                     .fractional_scale(fractional_scale)
                                     .binding(info)

--- a/exwlshellev/src/size.rs
+++ b/exwlshellev/src/size.rs
@@ -1,0 +1,227 @@
+//! Surface sizes, in the shapes the wayland protocols accept.
+//!
+//! A `0` is legal only on a layer surface axis, where `set_size` reads it as
+//! "the compositor assigns this one" and requires both opposite edges to be
+//! anchored. No other size here takes `0`.
+use std::num::NonZeroU32;
+
+use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::Anchor;
+
+const HORIZONTAL_EDGES: Anchor = Anchor::Left.union(Anchor::Right);
+const VERTICAL_EDGES: Anchor = Anchor::Top.union(Anchor::Bottom);
+
+/// The extent requested for a layer surface along one axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Extent {
+    /// exact extent as surface-local pixels
+    Exact(NonZeroU32),
+    /// let the compositor pick
+    Fill,
+}
+
+impl Extent {
+    /// exact extent, panics if 0. Use [`Extent::try_px`] for a run-time value
+    pub const fn px(value: u32) -> Self {
+        match NonZeroU32::new(value) {
+            Some(value) => Extent::Exact(value),
+            None => panic!(
+                "a layer surface extent must be non-zero. Use Extent::Fill to let the compositor pick it"
+            ),
+        }
+    }
+
+    /// exact extent, None on 0.
+    pub const fn try_px(value: u32) -> Option<Self> {
+        match NonZeroU32::new(value) {
+            Some(value) => Some(Extent::Exact(value)),
+            None => None,
+        }
+    }
+
+    /// if extent is left to the compositor
+    pub const fn is_fill(self) -> bool {
+        matches!(self, Extent::Fill)
+    }
+
+    /// the value to send in `set_size`: the extent, or `0` for [`Extent::Fill`]
+    pub const fn to_set(self) -> u32 {
+        match self {
+            Extent::Exact(value) => value.get(),
+            Extent::Fill => 0,
+        }
+    }
+}
+
+/// size requested for layer surface
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LayerSize {
+    pub width: Extent,
+    pub height: Extent,
+}
+
+impl LayerSize {
+    /// both axes left to the compositor, which needs all four anchor edges
+    pub const FILL: Self = LayerSize {
+        width: Extent::Fill,
+        height: Extent::Fill,
+    };
+
+    /// both axes exact. panics if either is 0.
+    pub const fn px(width: u32, height: u32) -> Self {
+        LayerSize {
+            width: Extent::px(width),
+            height: Extent::px(height),
+        }
+    }
+
+    /// compositor-chosen width, exact height. panic if height is 0
+    pub const fn fill_width(height: u32) -> Self {
+        LayerSize {
+            width: Extent::Fill,
+            height: Extent::px(height),
+        }
+    }
+
+    /// exact width, compositor-chosen height. panic if width is 0
+    pub const fn fill_height(width: u32) -> Self {
+        LayerSize {
+            width: Extent::px(width),
+            height: Extent::Fill,
+        }
+    }
+
+    /// anchor edges size requires
+    const fn required_anchor(self) -> Anchor {
+        let mut anchor = Anchor::empty();
+        if self.width.is_fill() {
+            anchor = anchor.union(HORIZONTAL_EDGES);
+        }
+        if self.height.is_fill() {
+            anchor = anchor.union(VERTICAL_EDGES);
+        }
+        anchor
+    }
+
+    /// edges that size requires and anchor does not have
+    pub const fn missing_edges(self, anchor: Anchor) -> Anchor {
+        self.required_anchor().difference(anchor)
+    }
+
+    /// add missing anchors
+    pub const fn resolve_anchor(self, anchor: Anchor) -> Anchor {
+        anchor.union(self.missing_edges(anchor))
+    }
+
+    /// width and height to set in set_size
+    pub const fn to_set(self) -> (u32, u32) {
+        (self.width.to_set(), self.height.to_set())
+    }
+}
+
+/// Exact, non-zero size in surface-local pixels, for sizes no protocol
+/// lets you ask the compositor to choose.
+///
+/// there is no `0` here that means "you pick", the way `set_size` has one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PixelSize {
+    pub width: NonZeroU32,
+    pub height: NonZeroU32,
+}
+
+impl PixelSize {
+    /// panics if either is 0. use [`PixelSize::try_px`] for run-time values
+    pub const fn px(width: u32, height: u32) -> Self {
+        match (NonZeroU32::new(width), NonZeroU32::new(height)) {
+            (Some(width), Some(height)) => PixelSize { width, height },
+            _ => panic!("a surface size must be non-zero on both axes"),
+        }
+    }
+
+    /// exact size, if either is 0 then None
+    pub const fn try_px(width: u32, height: u32) -> Option<Self> {
+        match (NonZeroU32::new(width), NonZeroU32::new(height)) {
+            (Some(width), Some(height)) => Some(PixelSize { width, height }),
+            _ => None,
+        }
+    }
+
+    pub const fn to_set(self) -> (u32, u32) {
+        (self.width.get(), self.height.get())
+    }
+
+    /// Same size for signed integer requests, capped at [`i32::MAX`]
+    /// so the value can never become negative on the set.
+    pub const fn to_set_i32(self) -> (i32, i32) {
+        const fn clamp(value: u32) -> i32 {
+            if value > i32::MAX as u32 {
+                i32::MAX
+            } else {
+                value as i32
+            }
+        }
+        (clamp(self.width.get()), clamp(self.height.get()))
+    }
+}
+
+/// check if positive exclusive zone is meaningful for anchor
+pub(crate) fn exclusive_zone_is_meaningful(anchor: Anchor) -> bool {
+    let spans_horizontally = anchor.contains(HORIZONTAL_EDGES);
+    let spans_vertically = anchor.contains(VERTICAL_EDGES);
+    match (spans_horizontally, spans_vertically) {
+        // all four edges: no free edge to reserve space from
+        (true, true) => false,
+        // an edge plus both perpendicular edges
+        (true, false) => anchor.intersects(VERTICAL_EDGES),
+        (false, true) => anchor.intersects(HORIZONTAL_EDGES),
+        // a corner, or nothing, invalid
+        (false, false) => anchor.bits().count_ones() == 1,
+    }
+}
+
+/// warn on positive zone paired with anchor the compositor clamps to zero.
+pub(crate) fn warn_if_exclusive_zone_ignored(zone: i32, anchor: Anchor) {
+    if zone > 0 && !exclusive_zone_is_meaningful(anchor) {
+        log::warn!(
+            "exclusive zone {zone} treated as 0: {anchor:?} is not a single edge, \
+             or an edge with both perpendicular ones"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: Anchor = HORIZONTAL_EDGES.union(VERTICAL_EDGES);
+
+    #[test]
+    fn exclusive_zone_meaningfulness_follows_the_spec() {
+        // one edge, and an edge with both perpendicular ones - either axis
+        for anchor in [
+            Anchor::Bottom,
+            Anchor::Bottom | Anchor::Left | Anchor::Right,
+            Anchor::Left | Anchor::Top | Anchor::Bottom,
+        ] {
+            assert!(exclusive_zone_is_meaningful(anchor), "{anchor:?}");
+        }
+        // nothing, a corner, two parallel edges, all four
+        for anchor in [
+            Anchor::empty(),
+            Anchor::Top | Anchor::Left,
+            Anchor::Left | Anchor::Right,
+            Anchor::Top | Anchor::Bottom,
+            ALL,
+        ] {
+            assert!(!exclusive_zone_is_meaningful(anchor), "{anchor:?}");
+        }
+    }
+
+    /// `0` at run-time is an `Option` to handle, not a panic
+    #[test]
+    fn a_zero_is_rejected_or_spelled_out() {
+        assert_eq!(Extent::try_px(0), None);
+        assert_eq!(PixelSize::try_px(0, 10), None);
+        assert_eq!(PixelSize::try_px(10, 0), None);
+        assert!(PixelSize::try_px(10, 10).is_some());
+    }
+}

--- a/iced_examples/application_launcher/src/main.rs
+++ b/iced_examples/application_launcher/src/main.rs
@@ -6,7 +6,7 @@ use iced::widget::{column, scrollable, text_input};
 use iced::{Element, Event, Length, Task as Command, event};
 use iced_layershell::actions::LayerShellCustomActionWithId;
 use iced_layershell::application;
-use iced_layershell::reexport::{Anchor, KeyboardInteractivity};
+use iced_layershell::reexport::{Anchor, KeyboardInteractivity, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, Settings};
 use iced_runtime::Action;
 
@@ -24,8 +24,8 @@ fn main() -> Result<(), iced_layershell::Error> {
     )
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((1000, 1000)),
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right | Anchor::Top,
+            size: LayerSize::px(1000, 1000),
+            anchor: Anchor::all(),
             keyboard_interactivity: KeyboardInteractivity::Exclusive,
             ..Default::default()
         },

--- a/iced_examples/bottom_panel/src/main.rs
+++ b/iced_examples/bottom_panel/src/main.rs
@@ -5,14 +5,14 @@ use iced::widget::{container, row};
 use iced::{Color, Element, Task};
 
 use iced_layershell::build_pattern::application;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::LayerShellSettings;
 use iced_layershell::to_layer_message;
 
 fn main() -> iced_layershell::Result {
     application(Panel::new, Panel::namespace, Panel::update, Panel::view)
         .layer_settings(LayerShellSettings {
-            size: Some((600, 50)),
+            size: LayerSize::px(600, 50),
             anchor: Anchor::Bottom,
             margin: (0, 0, 10, 0),
             ..Default::default()

--- a/iced_examples/counter/src/main.rs
+++ b/iced_examples/counter/src/main.rs
@@ -2,7 +2,7 @@ use iced::widget::{button, column, row, text, text_input};
 use iced::{Alignment, Color, Element, Event, Length, Task as Command, event};
 use iced_layershell::Settings;
 use iced_layershell::build_pattern::application;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, StartMode};
 use iced_layershell::to_layer_message;
 
@@ -18,9 +18,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
         .subscription(subscription)
         .settings(Settings {
             layer_settings: LayerShellSettings {
-                size: Some((0, 400)),
+                size: LayerSize::fill_width(400),
                 exclusive_zone: 400,
-                anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+                anchor: Anchor::Bottom,
                 start_mode,
                 ..Default::default()
             },
@@ -80,22 +80,22 @@ fn update(counter: &mut Counter, message: Message) -> Command<Message> {
             Command::none()
         }
         Message::Direction(direction) => match direction {
-            WindowDirection::Left => Command::done(Message::AnchorSizeChange(
-                Anchor::Left | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Right => Command::done(Message::AnchorSizeChange(
-                Anchor::Right | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Bottom => Command::done(Message::AnchorSizeChange(
-                Anchor::Bottom | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
-            WindowDirection::Top => Command::done(Message::AnchorSizeChange(
-                Anchor::Top | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
+            WindowDirection::Left => Command::done(Message::LayoutChange {
+                anchor: Anchor::Left,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Right => Command::done(Message::LayoutChange {
+                anchor: Anchor::Right,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Bottom => Command::done(Message::LayoutChange {
+                anchor: Anchor::Bottom,
+                size: LayerSize::fill_width(400),
+            }),
+            WindowDirection::Top => Command::done(Message::LayoutChange {
+                anchor: Anchor::Top,
+                size: LayerSize::fill_width(400),
+            }),
         },
         _ => unreachable!(),
     }

--- a/iced_examples/counter_multi/src/main.rs
+++ b/iced_examples/counter_multi/src/main.rs
@@ -9,7 +9,8 @@ use iced_runtime::{Action, task};
 
 use iced_layershell::daemon;
 use iced_layershell::reexport::{
-    Anchor, KeyboardInteractivity, Layer, NewLayerShellSettings, OutputOption, PopupGravity,
+    Anchor, KeyboardInteractivity, Layer, LayerSize, NewLayerShellSettings, OutputOption,
+    PixelSize, PopupGravity,
 };
 use iced_layershell::settings::{LayerShellSettings, Settings, StartMode};
 use iced_layershell::to_layer_message;
@@ -30,9 +31,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
     .subscription(Counter::subscription)
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((0, 400)),
+            size: LayerSize::fill_width(400),
             exclusive_zone: 400,
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+            anchor: Anchor::Bottom,
             start_mode: StartMode::AllScreens,
             ..Default::default()
         },
@@ -172,7 +173,7 @@ impl Counter {
                         self.ids.insert(id, WindowInfo::PopUp);
                         return Command::done(Message::NewMenu {
                             settings: IcedNewMenuSettings {
-                                size: (100, 100),
+                                size: PixelSize::px(100, 100),
                                 gravity: PopupGravity::TopRight,
                             },
                             id,
@@ -187,10 +188,10 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::TopBar);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        anchor: Anchor::Left | Anchor::Right | Anchor::Top,
+                        anchor: Anchor::Top,
                         layer: Layer::Top,
                         exclusive_zone: Some(30),
-                        size: Some((0, 30)),
+                        size: LayerSize::fill_width(30),
                         output_option: OutputOption::Output(wl_output),
                         ..Default::default()
                     },
@@ -210,25 +211,25 @@ impl Counter {
                 Command::none()
             }
             Message::Direction(direction) => match direction {
-                WindowDirection::Left(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Left(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Left | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Left,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Right(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Right(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Right | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Right,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Bottom(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Bottom(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Bottom,
-                    size: (0, 400),
+                    anchor: Anchor::Bottom,
+                    size: LayerSize::fill_width(400),
                 }),
-                WindowDirection::Top(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Top(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Top,
-                    size: (0, 400),
+                    anchor: Anchor::Top,
+                    size: LayerSize::fill_width(400),
                 }),
             },
             Message::NewWindowLeft => {
@@ -236,7 +237,7 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::Left);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: Some((100, 100)),
+                        size: LayerSize::px(100, 100),
                         exclusive_zone: None,
                         anchor: Anchor::Left | Anchor::Bottom,
                         layer: Layer::Top,

--- a/iced_examples/counter_output_select/src/main.rs
+++ b/iced_examples/counter_output_select/src/main.rs
@@ -2,7 +2,7 @@ use iced::widget::{button, column, row, text, text_input};
 use iced::{Alignment, Color, Element, Event, Length, Task as Command, event};
 use iced_layershell::Settings;
 use iced_layershell::build_pattern::application;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, StartMode};
 use iced_layershell::to_layer_message;
 
@@ -24,9 +24,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
         .subscription(subscription)
         .settings(Settings {
             layer_settings: LayerShellSettings {
-                size: Some((0, 400)),
+                size: LayerSize::fill_width(400),
                 exclusive_zone: 400,
-                anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+                anchor: Anchor::Bottom,
                 start_mode: StartMode::TargetOutput(output),
 
                 ..Default::default()
@@ -89,22 +89,22 @@ fn update(counter: &mut Counter, message: Message) -> Command<Message> {
         }
 
         Message::Direction(direction) => match direction {
-            WindowDirection::Left => Command::done(Message::AnchorSizeChange(
-                Anchor::Left | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Right => Command::done(Message::AnchorSizeChange(
-                Anchor::Right | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Bottom => Command::done(Message::AnchorSizeChange(
-                Anchor::Bottom | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
-            WindowDirection::Top => Command::done(Message::AnchorSizeChange(
-                Anchor::Top | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
+            WindowDirection::Left => Command::done(Message::LayoutChange {
+                anchor: Anchor::Left,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Right => Command::done(Message::LayoutChange {
+                anchor: Anchor::Right,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Bottom => Command::done(Message::LayoutChange {
+                anchor: Anchor::Bottom,
+                size: LayerSize::fill_width(400),
+            }),
+            WindowDirection::Top => Command::done(Message::LayoutChange {
+                anchor: Anchor::Top,
+                size: LayerSize::fill_width(400),
+            }),
         },
         _ => unreachable!(),
     }

--- a/iced_examples/counter_timer/src/main.rs
+++ b/iced_examples/counter_timer/src/main.rs
@@ -2,7 +2,7 @@ use iced::widget::{button, column, row, text, text_input};
 use iced::{Alignment, Color, Element, Event, Length, Subscription, Task as Command};
 use iced_layershell::Settings;
 use iced_layershell::build_pattern::timed;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, StartMode};
 use iced_layershell::to_layer_message;
 use std::time::Instant;
@@ -17,9 +17,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
         .style(style)
         .settings(Settings {
             layer_settings: LayerShellSettings {
-                size: Some((0, 400)),
+                size: LayerSize::fill_width(400),
                 exclusive_zone: 400,
-                anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+                anchor: Anchor::Bottom,
                 start_mode,
                 ..Default::default()
             },
@@ -75,22 +75,22 @@ fn update(counter: &mut Counter, message: Message, _time: Instant) -> Command<Me
             Command::none()
         }
         Message::Direction(direction) => match direction {
-            WindowDirection::Left => Command::done(Message::AnchorSizeChange(
-                Anchor::Left | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Right => Command::done(Message::AnchorSizeChange(
-                Anchor::Right | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Bottom => Command::done(Message::AnchorSizeChange(
-                Anchor::Bottom | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
-            WindowDirection::Top => Command::done(Message::AnchorSizeChange(
-                Anchor::Top | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
+            WindowDirection::Left => Command::done(Message::LayoutChange {
+                anchor: Anchor::Left,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Right => Command::done(Message::LayoutChange {
+                anchor: Anchor::Right,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Bottom => Command::done(Message::LayoutChange {
+                anchor: Anchor::Bottom,
+                size: LayerSize::fill_width(400),
+            }),
+            WindowDirection::Top => Command::done(Message::LayoutChange {
+                anchor: Anchor::Top,
+                size: LayerSize::fill_width(400),
+            }),
         },
         _ => unreachable!(),
     }

--- a/iced_examples/counter_universe/src/main.rs
+++ b/iced_examples/counter_universe/src/main.rs
@@ -8,8 +8,8 @@ use iced_runtime::window::Action as WindowAction;
 use iced_runtime::{Action, task};
 
 use iced_exwlshell::reexport::{
-    Anchor, KeyboardInteractivity, Layer, NewLayerShellSettings, OutputOption, PopupGravity,
-    WlShellType,
+    Anchor, KeyboardInteractivity, Layer, LayerSize, NewLayerShellSettings, OutputOption,
+    PixelSize, PopupGravity, WlShellType,
 };
 use iced_exwlshell::settings::{LayerShellSettings, Settings, StartMode};
 use iced_exwlshell::to_exwlshell_message;
@@ -31,7 +31,7 @@ pub fn main() -> Result<(), iced_exwlshell::Error> {
     .subscription(Counter::subscription)
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((0, 400)),
+            size: LayerSize::fill_width(400),
             exclusive_zone: 400,
             anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
             start_mode: StartMode::AllScreens,
@@ -176,8 +176,9 @@ impl Counter {
                             return Command::done(Message::NewPopUp {
                                 settings: IcedNewPopupSettings::new(
                                     parent,
-                                    (100, 100),
-                                    (0, 0, 1, 1),
+                                    PixelSize::px(100, 100),
+                                    (0, 0),
+                                    PixelSize::px(1, 1),
                                 )
                                 .gravity(PopupGravity::TopRight),
                                 id,
@@ -196,7 +197,7 @@ impl Counter {
                         anchor: Anchor::Left | Anchor::Right | Anchor::Top,
                         layer: Layer::Top,
                         exclusive_zone: Some(30),
-                        size: Some((0, 30)),
+                        size: LayerSize::fill_width(30),
                         output_option: OutputOption::Output(wl_output),
                         ..Default::default()
                     },
@@ -216,25 +217,25 @@ impl Counter {
                 Command::none()
             }
             Message::Direction(direction) => match direction {
-                WindowDirection::Left(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Left(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Left | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Left,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Right(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Right(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Right | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Right,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Bottom(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Bottom(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Bottom,
-                    size: (0, 400),
+                    anchor: Anchor::Bottom,
+                    size: LayerSize::fill_width(400),
                 }),
-                WindowDirection::Top(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Top(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Top,
-                    size: (0, 400),
+                    anchor: Anchor::Top,
+                    size: LayerSize::fill_width(400),
                 }),
             },
             Message::NewWindowLeft => {
@@ -242,7 +243,7 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::Left);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: Some((100, 100)),
+                        size: LayerSize::px(100, 100),
                         exclusive_zone: None,
                         anchor: Anchor::Left | Anchor::Bottom,
                         layer: Layer::Top,

--- a/iced_examples/iced_virtualkeyboard/src/main.rs
+++ b/iced_examples/iced_virtualkeyboard/src/main.rs
@@ -6,7 +6,7 @@ use iced::{Length, Point, Rectangle, Renderer, Size, Theme};
 use iced_layershell::actions::{LayerShellCustomAction, LayerShellCustomActionWithId};
 use iced_layershell::application;
 use iced_layershell::reexport::wl_keyboard::KeymapFormat;
-use iced_layershell::reexport::{Anchor, KeyboardInteractivity};
+use iced_layershell::reexport::{Anchor, KeyboardInteractivity, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, Settings, VirtualKeyboardSettings};
 use std::collections::HashMap;
 use std::ffi::CString;
@@ -139,7 +139,7 @@ fn main() -> Result<(), iced_layershell::Error> {
     .style(KeyboardView::style)
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((1200, 400)),
+            size: LayerSize::px(1200, 400),
             exclusive_zone: 400,
             anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
             keyboard_interactivity: KeyboardInteractivity::None,

--- a/iced_examples/input_regions/src/main.rs
+++ b/iced_examples/input_regions/src/main.rs
@@ -2,6 +2,7 @@ use iced::widget::{button, row};
 use iced::{Color, Element, Length, Task as Command};
 use iced_layershell::actions::ActionCallback;
 use iced_layershell::application;
+use iced_layershell::reexport::LayerSize;
 use iced_layershell::settings::LayerShellSettings;
 use iced_layershell::to_layer_message;
 
@@ -14,7 +15,7 @@ pub fn main() -> Result<(), iced_layershell::Error> {
     )
     .style(InputRegionExample::style)
     .layer_settings(LayerShellSettings {
-        size: Some((400, 400)),
+        size: LayerSize::px(400, 400),
         ..Default::default()
     })
     .run()

--- a/iced_examples/multi_window/src/main.rs
+++ b/iced_examples/multi_window/src/main.rs
@@ -5,7 +5,7 @@ use iced::widget::{
 use iced::window;
 use iced::{Center, Element, Fill, Subscription, Task, Theme, event};
 use iced_layershell::daemon;
-use iced_layershell::reexport::{Anchor, Layer, NewLayerShellSettings, OutputOption};
+use iced_layershell::reexport::{Anchor, Layer, LayerSize, NewLayerShellSettings, OutputOption};
 use iced_layershell::settings::{LayerShellSettings, Settings, StartMode};
 use iced_layershell::to_layer_message;
 use tracing_subscriber::layer::SubscriberExt;
@@ -70,13 +70,13 @@ impl Example {
             7 => Anchor::Left | Anchor::Bottom,
             _ => Anchor::Bottom,
         };
-        let size = (480, 320);
+        let size = LayerSize::px(480, 320);
         let id = window::Id::unique();
         (
             id,
             Task::done(Message::NewLayerShell {
                 settings: NewLayerShellSettings {
-                    size: Some(size),
+                    size,
                     exclusive_zone: None,
                     anchor,
                     layer: Layer::Top,

--- a/iced_examples/redraw/src/main.rs
+++ b/iced_examples/redraw/src/main.rs
@@ -21,14 +21,14 @@ use iced::{Element, Task};
 use std::time::{Duration, Instant};
 
 use iced_layershell::build_pattern::application;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::LayerShellSettings;
 use iced_layershell::to_layer_message;
 
 fn main() -> iced_layershell::Result {
     application(Panel::new, "Example", Panel::update, Panel::view)
         .layer_settings(LayerShellSettings {
-            size: Some((600, 50)),
+            size: LayerSize::px(600, 50),
             anchor: Anchor::empty(),
             ..Default::default()
         })

--- a/iced_examples/zbus_invoked_widget/src/main.rs
+++ b/iced_examples/zbus_invoked_widget/src/main.rs
@@ -8,7 +8,7 @@ use iced_runtime::window::Action as WindowAction;
 
 use iced_layershell::daemon;
 use iced_layershell::reexport::{
-    Anchor, KeyboardInteractivity, Layer, NewLayerShellSettings, OutputOption,
+    Anchor, KeyboardInteractivity, Layer, LayerSize, NewLayerShellSettings, OutputOption,
 };
 use iced_layershell::settings::{LayerShellSettings, StartMode};
 use zbus::{connection, interface};
@@ -120,7 +120,7 @@ impl Counter {
                 self.window_shown = true;
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: None,
+                        size: LayerSize::FILL,
                         exclusive_zone: None,
                         anchor: Anchor::Right | Anchor::Top | Anchor::Left | Anchor::Bottom,
                         layer: Layer::Top,

--- a/iced_exwlshell/README.md
+++ b/iced_exwlshell/README.md
@@ -33,8 +33,8 @@ use iced_runtime::window::Action as WindowAction;
 use iced_runtime::{Action, task};
 
 use iced_exwlshell::reexport::{
-    Anchor, KeyboardInteractivity, Layer, NewLayerShellSettings, OutputOption, PopupGravity,
-    WlShellType,
+    Anchor, KeyboardInteractivity, Layer, LayerSize, NewLayerShellSettings, OutputOption, PixelSize,
+    PopupGravity, WlShellType,
 };
 use iced_exwlshell::settings::{LayerShellSettings, Settings, StartMode};
 use iced_exwlshell::to_exwlshell_message;
@@ -56,7 +56,7 @@ pub fn main() -> Result<(), iced_exwlshell::Error> {
     .subscription(Counter::subscription)
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((0, 400)),
+            size: LayerSize::fill_width(400),
             exclusive_zone: 400,
             anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
             start_mode: StartMode::AllScreens,
@@ -199,7 +199,7 @@ impl Counter {
                             let id = iced::window::Id::unique();
                             self.ids.insert(id, WindowInfo::PopUp);
                             return Command::done(Message::NewPopUp {
-                                settings: IcedNewPopupSettings::new(parent, (100, 100), (0, 0, 1, 1))
+                                settings: IcedNewPopupSettings::new(parent, PixelSize::px(100, 100), (0, 0), PixelSize::px(1, 1))
                                     .gravity(PopupGravity::TopRight),
                                 id,
                             });
@@ -217,7 +217,7 @@ impl Counter {
                         anchor: Anchor::Left | Anchor::Right | Anchor::Top,
                         layer: Layer::Top,
                         exclusive_zone: Some(30),
-                        size: Some((0, 30)),
+                        size: LayerSize::fill_width(30),
                         output_option: OutputOption::Output(wl_output),
                         ..Default::default()
                     },
@@ -237,25 +237,25 @@ impl Counter {
                 Command::none()
             }
             Message::Direction(direction) => match direction {
-                WindowDirection::Left(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Left(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Left | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Left,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Right(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Right(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Right | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Right,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Bottom(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Bottom(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Bottom,
-                    size: (0, 400),
+                    anchor: Anchor::Bottom,
+                    size: LayerSize::fill_width(400),
                 }),
-                WindowDirection::Top(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Top(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Top,
-                    size: (0, 400),
+                    anchor: Anchor::Top,
+                    size: LayerSize::fill_width(400),
                 }),
             },
             Message::NewWindowLeft => {
@@ -263,7 +263,7 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::Left);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: Some((100, 100)),
+                        size: LayerSize::px(100, 100),
                         exclusive_zone: None,
                         anchor: Anchor::Left | Anchor::Bottom,
                         layer: Layer::Top,

--- a/iced_exwlshell/src/actions.rs
+++ b/iced_exwlshell/src/actions.rs
@@ -5,7 +5,8 @@ use exwlshellev::reexport::xdg_positioner::{
     Gravity as PopupGravity,
 };
 use exwlshellev::{
-    NewInputPanelSettings, NewLayerShellSettings, NewXdgWindowSettings, PopupPlacement,
+    LayerSize, NewInputPanelSettings, NewLayerShellSettings, NewXdgWindowSettings, PixelSize,
+    PopupPlacement,
 };
 use iced_core::window::Id as IcedId;
 
@@ -14,7 +15,7 @@ use std::sync::Arc;
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct IcedXdgWindowSettings {
     /// The initial window size.
-    pub size: Option<(u32, u32)>,
+    pub size: Option<PixelSize>,
     /// Request client-side decorations instead of the default server-side mode.
     pub client_side_decorations: bool,
 }
@@ -31,7 +32,7 @@ impl From<IcedXdgWindowSettings> for NewXdgWindowSettings {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct IcedNewPopupSettings {
-    pub size: (u32, u32),
+    pub size: PixelSize,
     pub parent: Option<IcedId>,
     pub placement: PopupPlacement,
     pub anchor: PopupAnchor,
@@ -40,23 +41,46 @@ pub struct IcedNewPopupSettings {
 }
 
 impl IcedNewPopupSettings {
-    pub fn new(parent: IcedId, size: (u32, u32), anchor_rect: (i32, i32, i32, i32)) -> Self {
-        Self::build(Some(parent), size, PopupPlacement::Anchored(anchor_rect))
+    pub fn new(
+        parent: IcedId,
+        size: PixelSize,
+        anchor_position: (i32, i32),
+        anchor_size: PixelSize,
+    ) -> Self {
+        Self::build(
+            Some(parent),
+            size,
+            PopupPlacement::Anchored {
+                position: anchor_position,
+                size: anchor_size,
+            },
+        )
     }
 
-    pub fn on_current_surface(size: (u32, u32), anchor_rect: (i32, i32, i32, i32)) -> Self {
-        Self::build(None, size, PopupPlacement::Anchored(anchor_rect))
+    pub fn on_current_surface(
+        size: PixelSize,
+        anchor_position: (i32, i32),
+        anchor_size: PixelSize,
+    ) -> Self {
+        Self::build(
+            None,
+            size,
+            PopupPlacement::Anchored {
+                position: anchor_position,
+                size: anchor_size,
+            },
+        )
     }
 
-    pub fn at_position(parent: IcedId, size: (u32, u32), position: (i32, i32)) -> Self {
+    pub fn at_position(parent: IcedId, size: PixelSize, position: (i32, i32)) -> Self {
         Self::build(Some(parent), size, PopupPlacement::Position(position))
     }
 
-    pub fn at_position_on_current_surface(size: (u32, u32), position: (i32, i32)) -> Self {
+    pub fn at_position_on_current_surface(size: PixelSize, position: (i32, i32)) -> Self {
         Self::build(None, size, PopupPlacement::Position(position))
     }
 
-    fn build(parent: Option<IcedId>, size: (u32, u32), placement: PopupPlacement) -> Self {
+    fn build(parent: Option<IcedId>, size: PixelSize, placement: PopupPlacement) -> Self {
         Self {
             size,
             parent,
@@ -94,7 +118,7 @@ impl IcedNewPopupSettings {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct IcedNewMenuSettings {
-    pub size: (u32, u32),
+    pub size: PixelSize,
     pub gravity: PopupGravity,
 }
 
@@ -123,11 +147,12 @@ impl ActionCallback {
 /// use macro to_layer_message
 #[derive(Debug, Clone)]
 pub enum ExwlShellCustomAction {
-    AnchorChange(Anchor),
+    LayoutChange {
+        anchor: Anchor,
+        size: LayerSize,
+    },
     LayerChange(Layer),
-    AnchorSizeChange(Anchor, (u32, u32)),
     MarginChange((i32, i32, i32, i32)),
-    SizeChange((u32, u32)),
     ExclusiveZoneChange(i32),
     KeyboardInteractivityChange(exwlshellev::reexport::KeyboardInteractivity),
     VirtualKeyboardPressed {

--- a/iced_exwlshell/src/build_pattern/daemon.md
+++ b/iced_exwlshell/src/build_pattern/daemon.md
@@ -12,8 +12,8 @@ use iced_runtime::window::Action as WindowAction;
 use iced_runtime::{Action, task};
 
 use iced_exwlshell::reexport::{
-    Anchor, KeyboardInteractivity, Layer, NewLayerShellSettings, OutputOption, PopupGravity,
-    WlShellType,
+    Anchor, KeyboardInteractivity, Layer, LayerSize, NewLayerShellSettings, OutputOption, PixelSize,
+    PopupGravity, WlShellType,
 };
 use iced_exwlshell::settings::{LayerShellSettings, Settings, StartMode};
 use iced_exwlshell::to_exwlshell_message;
@@ -35,7 +35,7 @@ pub fn main() -> Result<(), iced_exwlshell::Error> {
     .subscription(Counter::subscription)
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((0, 400)),
+            size: LayerSize::fill_width(400),
             exclusive_zone: 400,
             anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
             start_mode: StartMode::AllScreens,
@@ -178,7 +178,7 @@ impl Counter {
                             let id = iced::window::Id::unique();
                             self.ids.insert(id, WindowInfo::PopUp);
                             return Command::done(Message::NewPopUp {
-                                settings: IcedNewPopupSettings::new(parent, (100, 100), (0, 0, 1, 1))
+                                settings: IcedNewPopupSettings::new(parent, PixelSize::px(100, 100), (0, 0), PixelSize::px(1, 1))
                                     .gravity(PopupGravity::TopRight),
                                 id,
                             });
@@ -196,7 +196,7 @@ impl Counter {
                         anchor: Anchor::Left | Anchor::Right | Anchor::Top,
                         layer: Layer::Top,
                         exclusive_zone: Some(30),
-                        size: Some((0, 30)),
+                        size: LayerSize::fill_width(30),
                         output_option: OutputOption::Output(wl_output),
                         ..Default::default()
                     },
@@ -216,25 +216,25 @@ impl Counter {
                 Command::none()
             }
             Message::Direction(direction) => match direction {
-                WindowDirection::Left(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Left(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Left | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Left,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Right(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Right(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Right | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Right,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Bottom(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Bottom(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Bottom,
-                    size: (0, 400),
+                    anchor: Anchor::Bottom,
+                    size: LayerSize::fill_width(400),
                 }),
-                WindowDirection::Top(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Top(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Top,
-                    size: (0, 400),
+                    anchor: Anchor::Top,
+                    size: LayerSize::fill_width(400),
                 }),
             },
             Message::NewWindowLeft => {
@@ -242,7 +242,7 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::Left);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: Some((100, 100)),
+                        size: LayerSize::px(100, 100),
                         exclusive_zone: None,
                         anchor: Anchor::Left | Anchor::Bottom,
                         layer: Layer::Top,

--- a/iced_exwlshell/src/build_pattern/daemon.rs
+++ b/iced_exwlshell/src/build_pattern/daemon.rs
@@ -691,12 +691,6 @@ impl<P: Program> Daemon<P> {
             },
             ..Default::default()
         };
-        use exwlshellev::StartMode;
-        assert!(
-            settings.layer_settings.size.is_some()
-                || matches!(settings.layer_settings.start_mode, StartMode::Background),
-            "Size must be specified unless start_mode is Background"
-        );
         crate::multi_window::run(program, &self.namespace, settings, renderer_settings)
     }
 

--- a/iced_exwlshell/src/lib.rs
+++ b/iced_exwlshell/src/lib.rs
@@ -29,6 +29,7 @@ pub mod reexport {
         Anchor as PopupAnchor, ConstraintAdjustment as PopupConstraintAdjustment,
         Gravity as PopupGravity,
     };
+    pub use exwlshellev::{Extent, LayerSize, PixelSize};
     pub mod core {
         pub use iced_core::*;
     }

--- a/iced_exwlshell/src/multi_window.rs
+++ b/iced_exwlshell/src/multi_window.rs
@@ -126,7 +126,7 @@ where
         .with_start_mode(settings.layer_settings.start_mode)
         .with_use_display_handle(true)
         .with_events_transparent(settings.layer_settings.events_transparent)
-        .with_option_size(settings.layer_settings.size)
+        .with_size(settings.layer_settings.size)
         .with_layer(settings.layer_settings.layer)
         .with_anchor(settings.layer_settings.anchor)
         .with_exclusive_zone(settings.layer_settings.exclusive_zone)
@@ -800,13 +800,9 @@ where
                 ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);
                 exshell_window.set_blur_option(blur_option);
             }
-            ExwlShellCustomAction::AnchorChange(anchor) => {
+            ExwlShellCustomAction::LayoutChange { anchor, size } => {
                 ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);
-                exshell_window.set_anchor(anchor);
-            }
-            ExwlShellCustomAction::AnchorSizeChange(anchor, size) => {
-                ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);
-                exshell_window.set_anchor_with_size(anchor, size);
+                exshell_window.set_layout(anchor, size);
             }
             ExwlShellCustomAction::LayerChange(layer) => {
                 ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);
@@ -815,10 +811,6 @@ where
             ExwlShellCustomAction::MarginChange(margin) => {
                 ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);
                 exshell_window.set_margin(margin);
-            }
-            ExwlShellCustomAction::SizeChange((width, height)) => {
-                ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);
-                exshell_window.set_size((width, height));
             }
             ExwlShellCustomAction::ExclusiveZoneChange(zone_size) => {
                 ref_mut_exshell_window!(ev, iced_id, ex_shell_id, layer_shell_window);

--- a/iced_exwlshell/src/settings.rs
+++ b/iced_exwlshell/src/settings.rs
@@ -4,7 +4,7 @@ use iced_core::{Font, Pixels};
 
 use crate::reexport::{Anchor, KeyboardInteractivity, Layer, WithConnection};
 
-pub use exwlshellev::StartMode;
+pub use exwlshellev::{Extent, LayerSize, StartMode};
 
 use exwlshellev::{blur::BlurOption, reexport::wayland_client::wl_keyboard::KeymapFormat};
 
@@ -77,7 +77,7 @@ pub struct LayerShellSettings {
     pub anchor: Anchor,
     pub layer: Layer,
     pub exclusive_zone: i32,
-    pub size: Option<(u32, u32)>,
+    pub size: LayerSize,
     pub margin: (i32, i32, i32, i32),
     pub keyboard_interactivity: KeyboardInteractivity,
     pub start_mode: StartMode,
@@ -88,10 +88,10 @@ pub struct LayerShellSettings {
 impl Default for LayerShellSettings {
     fn default() -> Self {
         LayerShellSettings {
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+            anchor: Anchor::all(),
             layer: Layer::Top,
             exclusive_zone: -1,
-            size: None,
+            size: LayerSize::FILL,
             margin: (0, 0, 0, 0),
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
             events_transparent: false,
@@ -117,13 +117,10 @@ mod tests {
         assert!(settings.virtual_keyboard_support.is_none());
 
         // Test default layershellv settings
-        assert_eq!(
-            settings.layer_settings.anchor,
-            Anchor::Bottom | Anchor::Left | Anchor::Right
-        );
+        assert_eq!(settings.layer_settings.anchor, Anchor::all());
         assert_eq!(settings.layer_settings.layer, Layer::Top);
         assert_eq!(settings.layer_settings.exclusive_zone, -1);
-        assert_eq!(settings.layer_settings.size, None);
+        assert_eq!(settings.layer_settings.size, LayerSize::FILL);
         assert_eq!(settings.layer_settings.margin, (0, 0, 0, 0));
         assert_eq!(
             settings.layer_settings.keyboard_interactivity,
@@ -157,7 +154,7 @@ mod tests {
             anchor: Anchor::Top | Anchor::Left,
             layer: Layer::Background,
             exclusive_zone: 0,
-            size: Some((1920, 1080)),
+            size: LayerSize::px(1920, 1080),
             margin: (10, 10, 10, 10),
             keyboard_interactivity: KeyboardInteractivity::None,
             start_mode: StartMode::TargetScreen("HDMI-1".to_string()),
@@ -168,7 +165,7 @@ mod tests {
         assert_eq!(layer_settings.anchor, Anchor::Top | Anchor::Left);
         assert_eq!(layer_settings.layer, Layer::Background);
         assert_eq!(layer_settings.exclusive_zone, 0);
-        assert_eq!(layer_settings.size, Some((1920, 1080)));
+        assert_eq!(layer_settings.size, LayerSize::px(1920, 1080));
         assert_eq!(layer_settings.margin, (10, 10, 10, 10));
         assert_eq!(
             layer_settings.keyboard_interactivity,

--- a/iced_exwlshell/tests/test_macro.rs
+++ b/iced_exwlshell/tests/test_macro.rs
@@ -1,3 +1,4 @@
+use iced_exwlshell::reexport::{Anchor, LayerSize};
 use iced_exwlshell::to_exwlshell_message;
 
 #[test]
@@ -7,9 +8,10 @@ fn test_layer_message_macro() {
     enum TestEnum {
         TestA,
     }
-    let e = TestEnum::SizeChange {
+    let e = TestEnum::LayoutChange {
         id: iced::window::Id::unique(),
-        size: (1, 2),
+        anchor: Anchor::Bottom,
+        size: LayerSize::fill_width(30),
     };
     let _ = e.clone();
 }

--- a/iced_exwlshell_macros/src/lib.rs
+++ b/iced_exwlshell_macros/src/lib.rs
@@ -32,19 +32,15 @@ pub fn to_exwlshell_message(
             /// The new information about the new shell
             /// Must be addressed during update
             NewShell(iced_exwlshell::NewShellInfo),
-            /// Action , Anchor change
-            AnchorChange{id: iced_exwlshell::reexport::IcedId, anchor: iced_exwlshell::reexport::Anchor},
+            /// Action, Anchor and size change
+            LayoutChange{id: iced_exwlshell::reexport::IcedId, anchor: iced_exwlshell::reexport::Anchor, size: iced_exwlshell::reexport::LayerSize},
             /// Action, input region
             SetInputRegion{ id: iced_exwlshell::reexport::IcedId, callback: iced_exwlshell::actions::ActionCallback },
-            /// Action, anchor size change
-            AnchorSizeChange{id: iced_exwlshell::reexport::IcedId, anchor:iced_exwlshell::reexport::Anchor, size: (u32, u32)},
             /// Action, layer change
             LayerChange{id: iced_exwlshell::reexport::IcedId, layer:iced_exwlshell::reexport::Layer},
             /// Action, margin change Margin: top, left, bottom, right
             MarginChange{id: iced_exwlshell::reexport::IcedId, margin: (i32, i32, i32, i32)},
             BlurOptionChange{id: iced_exwlshell::reexport::IcedId, option: iced_exwlshell::reexport::BlurOption},
-            /// Action, size change
-            SizeChange{id: iced_exwlshell::reexport::IcedId, size: (u32, u32)},
             /// Action, ExclusiveZone Change
             ExclusiveZoneChange{id: iced_exwlshell::reexport::IcedId, zone_size: i32},
             /// Action, KeyboardInteractivity change
@@ -124,11 +120,9 @@ pub fn to_exwlshell_message(
 
                     match self {
                         Self::SetInputRegion{ id, callback } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::SetInputRegion(callback))),
-                        Self::AnchorChange { id, anchor } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::AnchorChange(anchor))),
-                        Self::AnchorSizeChange { id, anchor, size } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::AnchorSizeChange(anchor, size))),
+                        Self::LayoutChange { id, anchor, size } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::LayoutChange { anchor, size })),
                         Self::LayerChange { id, layer } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::LayerChange(layer))),
                         Self::MarginChange { id, margin } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::MarginChange(margin))),
-                        Self::SizeChange { id, size } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::SizeChange(size))),
                         Self::ExclusiveZoneChange { id, zone_size } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::ExclusiveZoneChange(zone_size))),
                         Self::KeyboardInteractivityChange { id, keyboard_interactivity } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::KeyboardInteractivityChange(keyboard_interactivity))),
                         Self::VirtualKeyboardPressed { key } => Ok(ExwlShellCustomActionWithId::new(

--- a/iced_layershell/README.md
+++ b/iced_layershell/README.md
@@ -21,7 +21,7 @@ The smallest example is like
 use iced::widget::{button, column, row, text, text_input};
 use iced::{Alignment, Color, Element, Event, Length, Task as Command, event};
 use iced_layershell::application;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, StartMode, Settings};
 use iced_layershell::to_layer_message;
 
@@ -37,9 +37,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
         .subscription(subscription)
         .settings(Settings {
             layer_settings: LayerShellSettings {
-                size: Some((0, 400)),
+                size: LayerSize::fill_width(400),
                 exclusive_zone: 400,
-                anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+                anchor: Anchor::Bottom,
                 start_mode,
                 ..Default::default()
             },
@@ -100,22 +100,22 @@ fn update(counter: &mut Counter, message: Message) -> Command<Message> {
         }
 
         Message::Direction(direction) => match direction {
-            WindowDirection::Left => Command::done(Message::AnchorSizeChange(
-                Anchor::Left | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Right => Command::done(Message::AnchorSizeChange(
-                Anchor::Right | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Bottom => Command::done(Message::AnchorSizeChange(
-                Anchor::Bottom | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
-            WindowDirection::Top => Command::done(Message::AnchorSizeChange(
-                Anchor::Top | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
+            WindowDirection::Left => Command::done(Message::LayoutChange {
+                anchor: Anchor::Left,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Right => Command::done(Message::LayoutChange {
+                anchor: Anchor::Right,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Bottom => Command::done(Message::LayoutChange {
+                anchor: Anchor::Bottom,
+                size: LayerSize::fill_width(400),
+            }),
+            WindowDirection::Top => Command::done(Message::LayoutChange {
+                anchor: Anchor::Top,
+                size: LayerSize::fill_width(400),
+            }),
         },
         _ => unreachable!(),
     }

--- a/iced_layershell/src/actions.rs
+++ b/iced_layershell/src/actions.rs
@@ -6,7 +6,8 @@ use layershellev::reexport::xdg_positioner::{
     Gravity as PopupGravity,
 };
 use layershellev::{
-    NewInputPanelSettings, NewLayerShellSettings, NewXdgWindowSettings, PopupPlacement,
+    LayerSize, NewInputPanelSettings, NewLayerShellSettings, NewXdgWindowSettings, PixelSize,
+    PopupPlacement,
 };
 
 use std::sync::Arc;
@@ -14,7 +15,7 @@ use std::sync::Arc;
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct IcedXdgWindowSettings {
     /// The initial window size.
-    pub size: Option<(u32, u32)>,
+    pub size: Option<PixelSize>,
     /// Request client-side decorations instead of the default server-side mode.
     pub client_side_decorations: bool,
 }
@@ -31,7 +32,7 @@ impl From<IcedXdgWindowSettings> for NewXdgWindowSettings {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct IcedNewPopupSettings {
-    pub size: (u32, u32),
+    pub size: PixelSize,
     pub parent: Option<IcedId>,
     pub placement: PopupPlacement,
     pub anchor: PopupAnchor,
@@ -40,30 +41,55 @@ pub struct IcedNewPopupSettings {
 }
 
 impl IcedNewPopupSettings {
-    /// Create popup settings for a popup of `size` anchored at `anchor_rect`
-    /// (in the parent surface's local coordinates) on the `parent` surface.
+    /// popup of `size`, anchored at the `anchor_position` + `anchor_size`
+    /// rectangle in the parent surface local coords
+    /// The rectangle cannot be empty, so pass `PixelSize::px(1, 1)` or
+    /// [`IcedNewPopupSettings::at_position`], which does the same
     ///
     /// Defaults are applied: anchored at the bottom-left of the anchor
     /// rect, growing toward the top-right, with the compositor free to flip
     /// or slide the popup on either axis to keep it on-screen. Override any of
     /// them with the builder methods.
-    pub fn new(parent: IcedId, size: (u32, u32), anchor_rect: (i32, i32, i32, i32)) -> Self {
-        Self::build(Some(parent), size, PopupPlacement::Anchored(anchor_rect))
+    pub fn new(
+        parent: IcedId,
+        size: PixelSize,
+        anchor_position: (i32, i32),
+        anchor_size: PixelSize,
+    ) -> Self {
+        Self::build(
+            Some(parent),
+            size,
+            PopupPlacement::Anchored {
+                position: anchor_position,
+                size: anchor_size,
+            },
+        )
     }
 
-    pub fn on_current_surface(size: (u32, u32), anchor_rect: (i32, i32, i32, i32)) -> Self {
-        Self::build(None, size, PopupPlacement::Anchored(anchor_rect))
+    pub fn on_current_surface(
+        size: PixelSize,
+        anchor_position: (i32, i32),
+        anchor_size: PixelSize,
+    ) -> Self {
+        Self::build(
+            None,
+            size,
+            PopupPlacement::Anchored {
+                position: anchor_position,
+                size: anchor_size,
+            },
+        )
     }
 
-    pub fn at_position(parent: IcedId, size: (u32, u32), position: (i32, i32)) -> Self {
+    pub fn at_position(parent: IcedId, size: PixelSize, position: (i32, i32)) -> Self {
         Self::build(Some(parent), size, PopupPlacement::Position(position))
     }
 
-    pub fn at_position_on_current_surface(size: (u32, u32), position: (i32, i32)) -> Self {
+    pub fn at_position_on_current_surface(size: PixelSize, position: (i32, i32)) -> Self {
         Self::build(None, size, PopupPlacement::Position(position))
     }
 
-    fn build(parent: Option<IcedId>, size: (u32, u32), placement: PopupPlacement) -> Self {
+    fn build(parent: Option<IcedId>, size: PixelSize, placement: PopupPlacement) -> Self {
         Self {
             size,
             parent,
@@ -101,7 +127,7 @@ impl IcedNewPopupSettings {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct IcedNewMenuSettings {
-    pub size: (u32, u32),
+    pub size: PixelSize,
     pub gravity: PopupGravity,
 }
 
@@ -130,11 +156,12 @@ impl ActionCallback {
 /// use macro to_layer_message
 #[derive(Debug, Clone)]
 pub enum LayerShellCustomAction {
-    AnchorChange(Anchor),
+    LayoutChange {
+        anchor: Anchor,
+        size: LayerSize,
+    },
     LayerChange(Layer),
-    AnchorSizeChange(Anchor, (u32, u32)),
     MarginChange((i32, i32, i32, i32)),
-    SizeChange((u32, u32)),
     ExclusiveZoneChange(i32),
     KeyboardInteractivityChange(layershellev::reexport::KeyboardInteractivity),
     VirtualKeyboardPressed {

--- a/iced_layershell/src/build_pattern/application.md
+++ b/iced_layershell/src/build_pattern/application.md
@@ -5,7 +5,7 @@
 use iced::widget::{button, column, row, text, text_input};
 use iced::{event, Alignment, Color, Element, Event, Length, Task as Command};
 use iced_layershell::application;
-use iced_layershell::reexport::Anchor;
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::settings::{LayerShellSettings, StartMode, Settings};
 use iced_layershell::to_layer_message;
 
@@ -27,9 +27,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
         .subscription(subscription)
         .settings(Settings {
             layer_settings: LayerShellSettings {
-                size: Some((0, 400)),
+                size: LayerSize::fill_width(400),
                 exclusive_zone: 400,
-                anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+                anchor: Anchor::Bottom,
                 start_mode,
                 ..Default::default()
             },
@@ -90,22 +90,22 @@ fn update(counter: &mut Counter, message: Message) -> Command<Message> {
         }
 
         Message::Direction(direction) => match direction {
-            WindowDirection::Left => Command::done(Message::AnchorSizeChange(
-                Anchor::Left | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Right => Command::done(Message::AnchorSizeChange(
-                Anchor::Right | Anchor::Top | Anchor::Bottom,
-                (400, 0),
-            )),
-            WindowDirection::Bottom => Command::done(Message::AnchorSizeChange(
-                Anchor::Bottom | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
-            WindowDirection::Top => Command::done(Message::AnchorSizeChange(
-                Anchor::Top | Anchor::Left | Anchor::Right,
-                (0, 400),
-            )),
+            WindowDirection::Left => Command::done(Message::LayoutChange {
+                anchor: Anchor::Left,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Right => Command::done(Message::LayoutChange {
+                anchor: Anchor::Right,
+                size: LayerSize::fill_height(400),
+            }),
+            WindowDirection::Bottom => Command::done(Message::LayoutChange {
+                anchor: Anchor::Bottom,
+                size: LayerSize::fill_width(400),
+            }),
+            WindowDirection::Top => Command::done(Message::LayoutChange {
+                anchor: Anchor::Top,
+                size: LayerSize::fill_width(400),
+            }),
         },
         _ => unreachable!(),
     }

--- a/iced_layershell/src/build_pattern/daemon.md
+++ b/iced_layershell/src/build_pattern/daemon.md
@@ -12,7 +12,7 @@ use iced_runtime::window::Action as WindowAction;
 use iced_runtime::{task, Action};
 
 use iced_layershell::build_pattern::daemon;
-use iced_layershell::reexport::{Anchor, KeyboardInteractivity, Layer, NewLayerShellSettings, OutputOption, PopupGravity};
+use iced_layershell::reexport::{Anchor, KeyboardInteractivity, Layer, LayerSize, NewLayerShellSettings, OutputOption, PixelSize, PopupGravity};
 use iced_layershell::settings::{LayerShellSettings, StartMode, Settings};
 use iced_layershell::to_layer_message;
 
@@ -26,9 +26,9 @@ pub fn main() -> Result<(), iced_layershell::Error> {
     .subscription(Counter::subscription)
     .settings(Settings {
         layer_settings: LayerShellSettings {
-            size: Some((0, 400)),
+            size: LayerSize::fill_width(400),
             exclusive_zone: 400,
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+            anchor: Anchor::Bottom,
             start_mode: StartMode::AllScreens,
             ..Default::default()
         },
@@ -142,7 +142,7 @@ impl Counter {
                             let id = iced::window::Id::unique();
                             self.ids.insert(id, WindowInfo::PopUp);
                             return Command::done(Message::NewPopUp {
-                                settings: IcedNewPopupSettings::new(parent, (100, 100), (0, 0, 1, 1))
+                                settings: IcedNewPopupSettings::new(parent, PixelSize::px(100, 100), (0, 0), PixelSize::px(1, 1))
                                     .gravity(PopupGravity::TopRight),
                                 id,
                             });
@@ -165,25 +165,25 @@ impl Counter {
                 Command::none()
             }
             Message::Direction(direction) => match direction {
-                WindowDirection::Left(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Left(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Left | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Left,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Right(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Right(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Top | Anchor::Right | Anchor::Bottom,
-                    size: (400, 0),
+                    anchor: Anchor::Right,
+                    size: LayerSize::fill_height(400),
                 }),
-                WindowDirection::Bottom(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Bottom(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Bottom,
-                    size: (0, 400),
+                    anchor: Anchor::Bottom,
+                    size: LayerSize::fill_width(400),
                 }),
-                WindowDirection::Top(id) => Command::done(Message::AnchorSizeChange {
+                WindowDirection::Top(id) => Command::done(Message::LayoutChange {
                     id,
-                    anchor: Anchor::Left | Anchor::Right | Anchor::Top,
-                    size: (0, 400),
+                    anchor: Anchor::Top,
+                    size: LayerSize::fill_width(400),
                 }),
             },
             Message::NewWindowLeft => {
@@ -191,7 +191,7 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::Left);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: Some((100, 100)),
+                        size: LayerSize::px(100, 100),
                         exclusive_zone: None,
                         anchor: Anchor::Left | Anchor::Bottom,
                         layer: Layer::Top,
@@ -208,7 +208,7 @@ impl Counter {
                 self.ids.insert(id, WindowInfo::Right);
                 Command::done(Message::NewLayerShell {
                     settings: NewLayerShellSettings {
-                        size: Some((100, 100)),
+                        size: LayerSize::px(100, 100),
                         exclusive_zone: None,
                         anchor: Anchor::Right | Anchor::Bottom,
                         layer: Layer::Top,

--- a/iced_layershell/src/build_pattern/daemon.rs
+++ b/iced_layershell/src/build_pattern/daemon.rs
@@ -686,12 +686,6 @@ impl<P: Program> Daemon<P> {
             },
             ..Default::default()
         };
-        use layershellev::StartMode;
-        assert!(
-            settings.layer_settings.size.is_some()
-                || matches!(settings.layer_settings.start_mode, StartMode::Background),
-            "Size must be specified unless start_mode is Background"
-        );
         crate::multi_window::run(program, &self.namespace, settings, renderer_settings)
     }
 

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -28,6 +28,7 @@ pub mod reexport {
         Anchor as PopupAnchor, ConstraintAdjustment as PopupConstraintAdjustment,
         Gravity as PopupGravity,
     };
+    pub use layershellev::{Extent, LayerSize, PixelSize};
     pub mod core {
         pub use iced_core::*;
     }

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -126,7 +126,7 @@ where
         .with_start_mode(settings.layer_settings.start_mode)
         .with_use_display_handle(true)
         .with_events_transparent(settings.layer_settings.events_transparent)
-        .with_option_size(settings.layer_settings.size)
+        .with_size(settings.layer_settings.size)
         .with_layer(settings.layer_settings.layer)
         .with_anchor(settings.layer_settings.anchor)
         .with_exclusive_zone(settings.layer_settings.exclusive_zone)
@@ -775,17 +775,13 @@ where
             return;
         }
         match action {
-            LayerShellCustomAction::AnchorChange(anchor) => {
-                ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);
-                layer_shell_window.set_anchor(anchor);
-            }
             LayerShellCustomAction::BlurOptionChange(option) => {
                 ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);
                 layer_shell_window.set_blur_option(option);
             }
-            LayerShellCustomAction::AnchorSizeChange(anchor, size) => {
+            LayerShellCustomAction::LayoutChange { anchor, size } => {
                 ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);
-                layer_shell_window.set_anchor_with_size(anchor, size);
+                layer_shell_window.set_layout(anchor, size);
             }
             LayerShellCustomAction::LayerChange(layer) => {
                 ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);
@@ -794,10 +790,6 @@ where
             LayerShellCustomAction::MarginChange(margin) => {
                 ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);
                 layer_shell_window.set_margin(margin);
-            }
-            LayerShellCustomAction::SizeChange((width, height)) => {
-                ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);
-                layer_shell_window.set_size((width, height));
             }
             LayerShellCustomAction::ExclusiveZoneChange(zone_size) => {
                 ref_mut_layer_shell_window!(ev, iced_id, layer_shell_id, layer_shell_window);

--- a/iced_layershell/src/settings.rs
+++ b/iced_layershell/src/settings.rs
@@ -5,6 +5,7 @@ use iced_core::{Font, Pixels};
 use crate::reexport::{Anchor, KeyboardInteractivity, Layer, WithConnection};
 
 pub use layershellev::StartMode;
+pub use layershellev::{Extent, LayerSize};
 
 use layershellev::{blur::BlurOption, reexport::wayland_client::wl_keyboard::KeymapFormat};
 
@@ -77,7 +78,7 @@ pub struct LayerShellSettings {
     pub anchor: Anchor,
     pub layer: Layer,
     pub exclusive_zone: i32,
-    pub size: Option<(u32, u32)>,
+    pub size: LayerSize,
     pub margin: (i32, i32, i32, i32),
     pub keyboard_interactivity: KeyboardInteractivity,
     pub start_mode: StartMode,
@@ -88,10 +89,10 @@ pub struct LayerShellSettings {
 impl Default for LayerShellSettings {
     fn default() -> Self {
         LayerShellSettings {
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+            anchor: Anchor::all(),
             layer: Layer::Top,
             exclusive_zone: -1,
-            size: None,
+            size: LayerSize::FILL,
             margin: (0, 0, 0, 0),
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
             events_transparent: false,
@@ -117,13 +118,10 @@ mod tests {
         assert!(settings.virtual_keyboard_support.is_none());
 
         // Test default layershellv settings
-        assert_eq!(
-            settings.layer_settings.anchor,
-            Anchor::Bottom | Anchor::Left | Anchor::Right
-        );
+        assert_eq!(settings.layer_settings.anchor, Anchor::all());
         assert_eq!(settings.layer_settings.layer, Layer::Top);
         assert_eq!(settings.layer_settings.exclusive_zone, -1);
-        assert_eq!(settings.layer_settings.size, None);
+        assert_eq!(settings.layer_settings.size, LayerSize::FILL);
         assert_eq!(settings.layer_settings.margin, (0, 0, 0, 0));
         assert_eq!(
             settings.layer_settings.keyboard_interactivity,
@@ -157,7 +155,7 @@ mod tests {
             anchor: Anchor::Top | Anchor::Left,
             layer: Layer::Background,
             exclusive_zone: 0,
-            size: Some((1920, 1080)),
+            size: LayerSize::px(1920, 1080),
             margin: (10, 10, 10, 10),
             keyboard_interactivity: KeyboardInteractivity::None,
             start_mode: StartMode::TargetScreen("HDMI-1".to_string()),
@@ -168,7 +166,7 @@ mod tests {
         assert_eq!(layer_settings.anchor, Anchor::Top | Anchor::Left);
         assert_eq!(layer_settings.layer, Layer::Background);
         assert_eq!(layer_settings.exclusive_zone, 0);
-        assert_eq!(layer_settings.size, Some((1920, 1080)));
+        assert_eq!(layer_settings.size, LayerSize::px(1920, 1080));
         assert_eq!(layer_settings.margin, (10, 10, 10, 10));
         assert_eq!(
             layer_settings.keyboard_interactivity,

--- a/iced_layershell/tests/test_macro.rs
+++ b/iced_layershell/tests/test_macro.rs
@@ -1,3 +1,4 @@
+use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::to_layer_message;
 
 #[test]
@@ -7,7 +8,10 @@ fn test_layer_message_macro() {
     enum TestEnum {
         TestA,
     }
-    let e = TestEnum::SizeChange((10, 10));
+    let e = TestEnum::LayoutChange {
+        anchor: Anchor::Bottom,
+        size: LayerSize::fill_width(30),
+    };
     let _ = e.clone();
 }
 

--- a/iced_layershell_macros/src/lib.rs
+++ b/iced_layershell_macros/src/lib.rs
@@ -37,14 +37,12 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
     let (additional_variants, impl_quote) = match is_multi {
         true => {
             let additional_variants = quote! {
-                AnchorChange{id: iced_layershell::reexport::IcedId, anchor: iced_layershell::reexport::Anchor},
+                LayoutChange{id: iced_layershell::reexport::IcedId, anchor: iced_layershell::reexport::Anchor, size: iced_layershell::reexport::LayerSize},
                 SetInputRegion{ id: iced_layershell::reexport::IcedId, callback: iced_layershell::actions::ActionCallback },
-                AnchorSizeChange{id: iced_layershell::reexport::IcedId, anchor:iced_layershell::reexport::Anchor, size: (u32, u32)},
                 LayerChange{id: iced_layershell::reexport::IcedId, layer:iced_layershell::reexport::Layer},
                 /// Margin: top, left, bottom, right
                 MarginChange{id: iced_layershell::reexport::IcedId, margin: (i32, i32, i32, i32)},
                 BlurOptionChange{id: iced_layershell::reexport::IcedId, option: iced_layershell::reexport::BlurOption},
-                SizeChange{id: iced_layershell::reexport::IcedId, size: (u32, u32)},
                 ExclusiveZoneChange{id: iced_layershell::reexport::IcedId, zone_size: i32},
                 KeyboardInteractivityChange{id: iced_layershell::reexport::IcedId, keyboard_interactivity: iced_layershell::reexport::KeyboardInteractivity},
                 VirtualKeyboardPressed {
@@ -103,11 +101,9 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
 
                         match self {
                             Self::SetInputRegion{ id, callback } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::SetInputRegion(callback))),
-                            Self::AnchorChange { id, anchor } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::AnchorChange(anchor))),
-                            Self::AnchorSizeChange { id, anchor, size } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::AnchorSizeChange(anchor, size))),
+                            Self::LayoutChange { id, anchor, size } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::LayoutChange{ anchor, size })),
                             Self::LayerChange { id, layer } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::LayerChange(layer))),
                             Self::MarginChange { id, margin } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::MarginChange(margin))),
-                            Self::SizeChange { id, size } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::SizeChange(size))),
                             Self::ExclusiveZoneChange { id, zone_size } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::ExclusiveZoneChange(zone_size))),
                             Self::KeyboardInteractivityChange { id, keyboard_interactivity } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::KeyboardInteractivityChange(keyboard_interactivity))),
                             Self::VirtualKeyboardPressed { key } => Ok(LayerShellCustomActionWithId::new(
@@ -131,14 +127,11 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
         }
         false => {
             let additional_variants = quote! {
-                AnchorChange(iced_layershell::reexport::Anchor),
+                LayoutChange { anchor: iced_layershell::reexport::Anchor, size: iced_layershell::reexport::LayerSize },
                 SetInputRegion(iced_layershell::actions::ActionCallback),
-                // Ancher and Size (width, height)
-                AnchorSizeChange(iced_layershell::reexport::Anchor, (u32, u32)),
                 LayerChange(iced_layershell::reexport::Layer),
                 /// Margin: top, left, bottom, right
                 MarginChange((i32, i32, i32, i32)),
-                SizeChange((u32, u32)),
                 ExclusiveZoneChange(i32),
                 KeyboardInteractivityChange(iced_layershell::reexport::KeyboardInteractivity),
                 VirtualKeyboardPressed {
@@ -156,12 +149,10 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
 
                         match self {
                             Self::SetInputRegion(callback) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::SetInputRegion(callback))),
-                            Self::AnchorChange(anchor) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::AnchorChange(anchor))),
-                            Self::AnchorSizeChange(anchor, size) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::AnchorSizeChange(anchor, size))),
+                            Self::LayoutChange { anchor, size } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::LayoutChange { anchor, size })),
                             Self::LayerChange(layer) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::LayerChange(layer))),
 
                             Self::MarginChange(margin) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::MarginChange(margin))),
-                            Self::SizeChange(size) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::SizeChange(size))),
                             Self::ExclusiveZoneChange(zone_size) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::ExclusiveZoneChange(zone_size))),
                             Self::KeyboardInteractivityChange(keyboard_interactivity) => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::KeyboardInteractivityChange(keyboard_interactivity))),
                             Self::VirtualKeyboardPressed { key } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::VirtualKeyboardPressed {

--- a/layershellev/examples/simplelayer.rs
+++ b/layershellev/examples/simplelayer.rs
@@ -8,7 +8,7 @@ use layershellev::*;
 fn main() {
     let ev: WindowState<()> = WindowState::new("Hello")
         .with_allscreens()
-        .with_size((0, 400))
+        .with_size(LayerSize::fill_width(400))
         .with_layer(Layer::Top)
         .with_margin((20, 20, 100, 20))
         .with_anchor(Anchor::Bottom | Anchor::Left | Anchor::Right)

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -20,6 +20,8 @@ use wayland_client::{
     },
 };
 
+use crate::size::{LayerSize, PixelSize};
+
 use crate::{blur::BlurOption, id, xkb_keyboard::KeyEvent};
 
 use crate::keyboard::ModifiersState;
@@ -91,8 +93,8 @@ pub enum OutputOption {
 /// layershell settings to create a new layershell surface
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewLayerShellSettings {
-    /// the size of the layershell, optional.
-    pub size: Option<(u32, u32)>,
+    /// the size of the layershell
+    pub size: LayerSize,
     pub layer: Layer,
     pub anchor: Anchor,
     pub exclusive_zone: Option<i32>,
@@ -110,8 +112,13 @@ pub struct NewLayerShellSettings {
 /// How a popup is positioned relative to its parent surface
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PopupPlacement {
-    /// anchor rectangle in the parent surface's local coordinates (x, y, w, h)
-    Anchored((i32, i32, i32, i32)),
+    /// anchor rectangle in the parent surface's local coordinates
+    Anchored {
+        /// the top-left corner of the anchor rectangle
+        position: (i32, i32),
+        /// the extents of the anchor rectangle
+        size: PixelSize,
+    },
     /// Absolute position of the popup in the parent surface's local coordinates
     Position((i32, i32)),
 }
@@ -120,7 +127,7 @@ pub enum PopupPlacement {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct NewPopUpSettings {
     /// the size of the popup
-    pub size: (u32, u32),
+    pub size: PixelSize,
     /// the id of the parent surface
     pub id: id::Id,
     /// How a popup is positioned relative to its parent surface
@@ -140,7 +147,7 @@ pub struct NewXdgWindowSettings {
     /// The window title.
     pub title: Option<String>,
     /// The initial window size.
-    pub size: Option<(u32, u32)>,
+    pub size: Option<PixelSize>,
     /// Request client-side decorations instead of the default server-side mode.
     pub client_side_decorations: bool,
 }
@@ -148,7 +155,7 @@ pub struct NewXdgWindowSettings {
 /// input panel settings to create a new input panel surface
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewInputPanelSettings {
-    pub size: (u32, u32),
+    pub size: PixelSize,
     /// set the surface type as a keyboard
     pub keyboard: bool,
     /// follow the last output of the activated surface, used to create some thing like mako, who
@@ -160,10 +167,10 @@ pub struct NewInputPanelSettings {
 impl Default for NewLayerShellSettings {
     fn default() -> Self {
         NewLayerShellSettings {
-            anchor: Anchor::Bottom | Anchor::Left | Anchor::Right,
+            anchor: Anchor::all(),
             layer: Layer::Top,
             exclusive_zone: None,
-            size: None,
+            size: LayerSize::FILL,
             margin: Some((0, 0, 0, 0)),
             keyboard_interactivity: KeyboardInteractivity::OnDemand,
             blur_option: BlurOption::None,

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -13,7 +13,7 @@
 //! fn main() {
 //!     let mut ev: WindowState<()> = WindowState::new("Hello")
 //!         .with_allscreens()
-//!         .with_size((0, 400))
+//!         .with_size(LayerSize::fill_width(400))
 //!         .with_layer(Layer::Top)
 //!         .with_margin((20, 20, 100, 20))
 //!         .with_anchor(Anchor::Bottom | Anchor::Left | Anchor::Right)
@@ -113,8 +113,12 @@ pub mod blur;
 pub mod dpi;
 mod events;
 mod seat;
+mod size;
 mod strtoshape;
+
 use events::DispatchMessageInner;
+use size::warn_if_exclusive_zone_ignored;
+pub use size::{Extent, LayerSize, PixelSize};
 
 pub mod id;
 
@@ -402,6 +406,8 @@ impl<T> WindowStateUnitBuilder<T> {
                 shell,
                 parent: None,
                 size: (0, 0),
+                anchor: Anchor::empty(),
+                layer_size: LayerSize::FILL,
                 buffer: Default::default(),
                 fractional_scale: Default::default(),
                 viewport: Default::default(),
@@ -425,6 +431,12 @@ impl<T> WindowStateUnitBuilder<T> {
 
     fn size(mut self, size: (u32, u32)) -> Self {
         self.inner.size = size;
+        self
+    }
+
+    fn layout(mut self, anchor: Anchor, layer_size: LayerSize) -> Self {
+        self.inner.anchor = anchor;
+        self.inner.layer_size = layer_size;
         self
     }
 
@@ -498,6 +510,10 @@ pub struct WindowStateUnit<T> {
     wl_surface: WlSurface,
     wmcompositor: WlCompositor,
     size: (u32, u32),
+    /// Only meaningful for LayerShell
+    anchor: Anchor,
+    /// Only meaningful for LayerShell
+    layer_size: LayerSize,
     buffer: Option<WlBuffer>,
     shell: Shell,
     parent: Option<id::Id>,
@@ -525,6 +541,16 @@ impl<T> WindowStateUnit<T> {
 
     pub fn try_set_viewport_destination(&self, width: i32, height: i32) -> Option<()> {
         let viewport = self.viewport.as_ref()?;
+        // (-1, -1) unsets the destination
+        if (width, height) != (-1, -1) && (width <= 0 || height <= 0) {
+            log::warn!(
+                target: "layershellev",
+                "ignoring viewport destination {width}x{height} for {:?}: wp_viewport requires \
+                 positive dimensions, or (-1, -1) to unset",
+                self.id
+            );
+            return None;
+        }
         viewport.set_destination(width, height);
         Some(())
     }
@@ -654,12 +680,41 @@ impl<T> WindowStateUnit<T> {
     pub fn get_wloutput(&self) -> Option<&WlOutput> {
         self.wl_output.as_ref()
     }
-    /// set the anchor of the current unit. please take the simple.rs as reference
-    pub fn set_anchor(&self, anchor: Anchor) {
-        if let Shell::LayerShell(layer_shell) = &self.shell {
-            layer_shell.set_anchor(anchor);
-            self.wl_surface.commit();
+
+    /// last requested anchor for surface
+    pub fn get_anchor(&self) -> Anchor {
+        self.anchor
+    }
+
+    /// actual layer surface anchor
+    pub fn get_effective_anchor(&self) -> Anchor {
+        if !matches!(self.shell, Shell::LayerShell(_)) {
+            return Anchor::empty();
         }
+        self.anchor | self.layer_size.missing_edges(self.anchor)
+    }
+
+    /// last requested size for surface
+    pub fn get_layer_size(&self) -> LayerSize {
+        self.layer_size
+    }
+
+    /// commit anchor and size, while adding required edges for size
+    fn commit_layout(&mut self, anchor: Anchor, size: LayerSize) {
+        let Shell::LayerShell(layer_shell) = &self.shell else {
+            return;
+        };
+        let (width, height) = size.to_set();
+        layer_shell.set_anchor(size.resolve_anchor(anchor));
+        layer_shell.set_size(width, height);
+        self.anchor = anchor;
+        self.layer_size = size;
+        self.wl_surface.commit();
+    }
+
+    /// set the anchor of the current unit. please take the simple.rs as reference
+    pub fn set_anchor(&mut self, anchor: Anchor) {
+        self.commit_layout(anchor, self.layer_size);
     }
 
     /// you can reset the margin which bind to the surface
@@ -679,26 +734,20 @@ impl<T> WindowStateUnit<T> {
     }
 
     /// set the anchor and set the size together
-    /// When you want to change layer from LEFT|RIGHT|BOTTOM to TOP|LEFT|BOTTOM, use it
-    pub fn set_anchor_with_size(&self, anchor: Anchor, (width, height): (u32, u32)) {
-        if let Shell::LayerShell(layer_shell) = &self.shell {
-            layer_shell.set_anchor(anchor);
-            layer_shell.set_size(width, height);
-            self.wl_surface.commit();
-        }
+    /// When you want to change the layout from LEFT|RIGHT|BOTTOM to TOP|LEFT|BOTTOM, use it.
+    pub fn set_layout(&mut self, anchor: Anchor, size: LayerSize) {
+        self.commit_layout(anchor, size);
     }
 
     /// set the layer size of current unit
-    pub fn set_size(&self, (width, height): (u32, u32)) {
-        if let Shell::LayerShell(layer_shell) = &self.shell {
-            layer_shell.set_size(width, height);
-            self.wl_surface.commit();
-        }
+    pub fn set_size(&mut self, size: LayerSize) {
+        self.commit_layout(self.anchor, size);
     }
 
     /// set current exclusive_zone
     pub fn set_exclusive_zone(&self, zone: i32) {
         if let Shell::LayerShell(layer_shell) = &self.shell {
+            warn_if_exclusive_zone_ignored(zone, self.get_effective_anchor());
             layer_shell.set_exclusive_zone(zone);
             self.wl_surface.commit();
         }
@@ -951,7 +1000,7 @@ pub struct WindowState<T> {
     keyboard_interactivity: zwlr_layer_surface_v1::KeyboardInteractivity,
     anchor: Anchor,
     layer: Layer,
-    size: Option<(u32, u32)>,
+    size: LayerSize,
     exclusive_zone: Option<i32>,
     margin: Option<(i32, i32, i32, i32)>,
     blur_option: BlurOption,
@@ -1431,17 +1480,11 @@ impl<T> WindowState<T> {
         self
     }
 
-    /// if not set, it will be the size suggested by layer_shell, like anchor to four ways,
-    /// and margins to 0,0,0,0 , the size will be the size of screen.
+    /// if not set, the default is [`LayerSize::FILL`], which with the default four-edge
+    /// anchor and margins to 0,0,0,0 gives a surface the size of the screen.
     ///
     /// if set, layer_shell will use the size you set
-    pub fn with_size(mut self, size: (u32, u32)) -> Self {
-        self.size = Some(size);
-        self
-    }
-
-    /// set the window size, optional
-    pub fn with_option_size(mut self, size: Option<(u32, u32)>) -> Self {
+    pub fn with_size(mut self, size: LayerSize) -> Self {
         self.size = size;
         self
     }
@@ -1501,7 +1544,7 @@ impl<T> Default for WindowState<T> {
             keyboard_interactivity: zwlr_layer_surface_v1::KeyboardInteractivity::OnDemand,
             layer: Layer::Overlay,
             anchor: Anchor::Top | Anchor::Left | Anchor::Right | Anchor::Bottom,
-            size: None,
+            size: LayerSize::FILL,
             exclusive_zone: None,
             margin: None,
             blur_option: BlurOption::None,
@@ -2217,13 +2260,14 @@ impl<T: 'static> WindowState<T> {
                 &qh,
                 (),
             );
-            layer.set_anchor(self.anchor);
+            let wire_anchor = self.size.resolve_anchor(self.anchor);
+            layer.set_anchor(wire_anchor);
             layer.set_keyboard_interactivity(self.keyboard_interactivity);
-            if let Some((init_w, init_h)) = self.size {
-                layer.set_size(init_w, init_h);
-            }
+            let (init_w, init_h) = self.size.to_set();
+            layer.set_size(init_w, init_h);
 
             if let Some(zone) = self.exclusive_zone {
+                warn_if_exclusive_zone_ignored(zone, wire_anchor);
                 layer.set_exclusive_zone(zone);
             }
 
@@ -2266,6 +2310,7 @@ impl<T: 'static> WindowState<T> {
                     Shell::LayerShell(layer),
                 )
                 .blur_option(self.blur_option.clone())
+                .layout(self.anchor, self.size)
                 .viewport(viewport)
                 .effect_surface(effect)
                 .fractional_scale(fractional_scale)
@@ -2287,13 +2332,14 @@ impl<T: 'static> WindowState<T> {
                     &qh,
                     (),
                 );
-                layer.set_anchor(self.anchor);
+                let wire_anchor = self.size.resolve_anchor(self.anchor);
+                layer.set_anchor(wire_anchor);
                 layer.set_keyboard_interactivity(self.keyboard_interactivity);
-                if let Some((init_w, init_h)) = self.size {
-                    layer.set_size(init_w, init_h);
-                }
+                let (init_w, init_h) = self.size.to_set();
+                layer.set_size(init_w, init_h);
 
                 if let Some(zone) = self.exclusive_zone {
+                    warn_if_exclusive_zone_ignored(zone, wire_anchor);
                     layer.set_exclusive_zone(zone);
                 }
 
@@ -2334,6 +2380,7 @@ impl<T: 'static> WindowState<T> {
                         wmcompositer.clone(),
                         Shell::LayerShell(layer),
                     )
+                    .layout(self.anchor, self.size)
                     .viewport(viewport)
                     .blur_option(self.blur_option.clone())
                     .effect_surface(effect)
@@ -2482,13 +2529,14 @@ impl<T: 'static> WindowState<T> {
                             &qh,
                             (),
                         );
-                        layer.set_anchor(window_state.anchor);
+                        let wire_anchor = window_state.size.resolve_anchor(window_state.anchor);
+                        layer.set_anchor(wire_anchor);
                         layer.set_keyboard_interactivity(window_state.keyboard_interactivity);
-                        if let Some((init_w, init_h)) = window_state.size {
-                            layer.set_size(init_w, init_h);
-                        }
+                        let (init_w, init_h) = window_state.size.to_set();
+                        layer.set_size(init_w, init_h);
 
                         if let Some(zone) = window_state.exclusive_zone {
+                            warn_if_exclusive_zone_ignored(zone, wire_anchor);
                             layer.set_exclusive_zone(zone);
                         }
 
@@ -2530,6 +2578,7 @@ impl<T: 'static> WindowState<T> {
                                 wmcompositer.clone(),
                                 Shell::LayerShell(layer),
                             )
+                            .layout(window_state.anchor, window_state.size)
                             .viewport(viewport)
                             .blur_option(window_state.blur_option.clone())
                             .effect_surface(effect)
@@ -2584,6 +2633,7 @@ impl<T: 'static> WindowState<T> {
                             id,
                             info,
                         )) => {
+                            let wire_anchor = size.resolve_anchor(anchor);
                             let output = match output_type {
                                 OutputOption::Output(output) => Some(output),
                                 OutputOption::OutputName(name) => {
@@ -2605,13 +2655,13 @@ impl<T: 'static> WindowState<T> {
                                 &qh,
                                 (),
                             );
-                            layer.set_anchor(anchor);
+                            layer.set_anchor(wire_anchor);
                             layer.set_keyboard_interactivity(keyboard_interactivity);
-                            if let Some((init_w, init_h)) = size {
-                                layer.set_size(init_w, init_h);
-                            }
+                            let (init_w, init_h) = size.to_set();
+                            layer.set_size(init_w, init_h);
 
                             if let Some(zone) = exclusive_zone {
+                                warn_if_exclusive_zone_ignored(zone, wire_anchor);
                                 layer.set_exclusive_zone(zone);
                             }
 
@@ -2655,6 +2705,7 @@ impl<T: 'static> WindowState<T> {
                                 )
                                 .blur_option(blur_option)
                                 .effect_surface(effect)
+                                .layout(anchor, size)
                                 .viewport(viewport)
                                 .fractional_scale(fractional_scale)
                                 .wl_output(output)
@@ -2665,7 +2716,7 @@ impl<T: 'static> WindowState<T> {
                         }
                         ReturnData::NewPopUp((
                             NewPopUpSettings {
-                                size: (width, height),
+                                size,
                                 id,
                                 placement,
                                 anchor,
@@ -2676,22 +2727,6 @@ impl<T: 'static> WindowState<T> {
                             targetid,
                             info,
                         )) => {
-                            if width == 0 || height == 0 {
-                                log::warn!(
-                                    target: "layershellev",
-                                    "popup {targetid:?} size must be positive, got {width}x{height}; skipping popup creation"
-                                );
-                                continue;
-                            }
-                            if let PopupPlacement::Anchored((_, _, arw, arh)) = placement
-                                && (arw < 0 || arh < 0)
-                            {
-                                log::warn!(
-                                    target: "layershellev",
-                                    "popup {targetid:?} anchor_rect dimensions must be non-negative, got ({arw}, {arh}); skipping popup creation"
-                                );
-                                continue;
-                            }
                             let Some(index) =
                                 window_state.units.iter().position(|unit| unit.id == id)
                             else {
@@ -2699,12 +2734,17 @@ impl<T: 'static> WindowState<T> {
                             };
                             let wl_surface = wmcompositer.create_surface(&qh, ());
                             let positioner = wmbase.create_positioner(&qh, ());
-                            positioner.set_size(width as i32, height as i32);
+                            let (width, height) = size.to_set_i32();
+                            positioner.set_size(width, height);
                             match placement {
                                 PopupPlacement::Position((px, py)) => {
                                     positioner.set_anchor_rect(px, py, 1, 1)
                                 }
-                                PopupPlacement::Anchored((arx, ary, arw, arh)) => {
+                                PopupPlacement::Anchored {
+                                    position: (arx, ary),
+                                    size: rect,
+                                } => {
+                                    let (arw, arh) = rect.to_set_i32();
                                     positioner.set_anchor_rect(arx, ary, arw, arh)
                                 }
                             }
@@ -2774,7 +2814,7 @@ impl<T: 'static> WindowState<T> {
                                     Shell::PopUp((popup, wl_xdg_surface)),
                                 )
                                 .parent(Some(id))
-                                .size((width, height))
+                                .size(size.to_set())
                                 .viewport(viewport)
                                 .fractional_scale(fractional_scale)
                                 .binding(info)
@@ -2835,7 +2875,7 @@ impl<T: 'static> WindowState<T> {
                                     wmcompositer.clone(),
                                     Shell::XdgTopLevel((toplevel, wl_xdg_surface, decoration)),
                                 )
-                                .size(size.unwrap_or((300, 300)))
+                                .size(size.unwrap_or(PixelSize::px(300, 300)).to_set())
                                 .viewport(viewport)
                                 .fractional_scale(fractional_scale)
                                 .binding(info)
@@ -2846,7 +2886,7 @@ impl<T: 'static> WindowState<T> {
 
                         ReturnData::NewInputPanel((
                             NewInputPanelSettings {
-                                size: (width, height),
+                                size,
                                 keyboard,
                                 output_option: output_type,
                             },
@@ -2905,7 +2945,7 @@ impl<T: 'static> WindowState<T> {
                                     wmcompositer.clone(),
                                     Shell::InputPanel(input_panel_surface),
                                 )
-                                .size((width, height))
+                                .size(size.to_set())
                                 .viewport(viewport)
                                 .fractional_scale(fractional_scale)
                                 .binding(info)

--- a/layershellev/src/size.rs
+++ b/layershellev/src/size.rs
@@ -1,0 +1,227 @@
+//! Surface sizes, in the shapes the wayland protocols accept.
+//!
+//! A `0` is legal only on a layer surface axis, where `set_size` reads it as
+//! "the compositor assigns this one" and requires both opposite edges to be
+//! anchored. No other size here takes `0`.
+use std::num::NonZeroU32;
+
+use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::Anchor;
+
+const HORIZONTAL_EDGES: Anchor = Anchor::Left.union(Anchor::Right);
+const VERTICAL_EDGES: Anchor = Anchor::Top.union(Anchor::Bottom);
+
+/// The extent requested for a layer surface along one axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Extent {
+    /// exact extent as surface-local pixels
+    Exact(NonZeroU32),
+    /// let the compositor pick
+    Fill,
+}
+
+impl Extent {
+    /// exact extent, panics if 0. Use [`Extent::try_px`] for a run-time value
+    pub const fn px(value: u32) -> Self {
+        match NonZeroU32::new(value) {
+            Some(value) => Extent::Exact(value),
+            None => panic!(
+                "a layer surface extent must be non-zero. Use Extent::Fill to let the compositor pick it"
+            ),
+        }
+    }
+
+    /// exact extent, None on 0.
+    pub const fn try_px(value: u32) -> Option<Self> {
+        match NonZeroU32::new(value) {
+            Some(value) => Some(Extent::Exact(value)),
+            None => None,
+        }
+    }
+
+    /// if extent is left to the compositor
+    pub const fn is_fill(self) -> bool {
+        matches!(self, Extent::Fill)
+    }
+
+    /// the value to send in `set_size`: the extent, or `0` for [`Extent::Fill`]
+    pub const fn to_set(self) -> u32 {
+        match self {
+            Extent::Exact(value) => value.get(),
+            Extent::Fill => 0,
+        }
+    }
+}
+
+/// size requested for layer surface
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LayerSize {
+    pub width: Extent,
+    pub height: Extent,
+}
+
+impl LayerSize {
+    /// both axes left to the compositor, which needs all four anchor edges
+    pub const FILL: Self = LayerSize {
+        width: Extent::Fill,
+        height: Extent::Fill,
+    };
+
+    /// both axes exact. panics if either is 0.
+    pub const fn px(width: u32, height: u32) -> Self {
+        LayerSize {
+            width: Extent::px(width),
+            height: Extent::px(height),
+        }
+    }
+
+    /// compositor-chosen width, exact height. panic if height is 0
+    pub const fn fill_width(height: u32) -> Self {
+        LayerSize {
+            width: Extent::Fill,
+            height: Extent::px(height),
+        }
+    }
+
+    /// exact width, compositor-chosen height. panic if width is 0
+    pub const fn fill_height(width: u32) -> Self {
+        LayerSize {
+            width: Extent::px(width),
+            height: Extent::Fill,
+        }
+    }
+
+    /// anchor edges size requires
+    const fn required_anchor(self) -> Anchor {
+        let mut anchor = Anchor::empty();
+        if self.width.is_fill() {
+            anchor = anchor.union(HORIZONTAL_EDGES);
+        }
+        if self.height.is_fill() {
+            anchor = anchor.union(VERTICAL_EDGES);
+        }
+        anchor
+    }
+
+    /// edges that size requires and anchor does not have
+    pub const fn missing_edges(self, anchor: Anchor) -> Anchor {
+        self.required_anchor().difference(anchor)
+    }
+
+    /// add missing anchors
+    pub const fn resolve_anchor(self, anchor: Anchor) -> Anchor {
+        anchor.union(self.missing_edges(anchor))
+    }
+
+    /// width and height to set in set_size
+    pub const fn to_set(self) -> (u32, u32) {
+        (self.width.to_set(), self.height.to_set())
+    }
+}
+
+/// Exact, non-zero size in surface-local pixels, for sizes no protocol
+/// lets you ask the compositor to choose.
+///
+/// there is no `0` here that means "you pick", the way `set_size` has one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PixelSize {
+    pub width: NonZeroU32,
+    pub height: NonZeroU32,
+}
+
+impl PixelSize {
+    /// panics if either is 0. use [`PixelSize::try_px`] for run-time values
+    pub const fn px(width: u32, height: u32) -> Self {
+        match (NonZeroU32::new(width), NonZeroU32::new(height)) {
+            (Some(width), Some(height)) => PixelSize { width, height },
+            _ => panic!("a surface size must be non-zero on both axes"),
+        }
+    }
+
+    /// exact size, if either is 0 then None
+    pub const fn try_px(width: u32, height: u32) -> Option<Self> {
+        match (NonZeroU32::new(width), NonZeroU32::new(height)) {
+            (Some(width), Some(height)) => Some(PixelSize { width, height }),
+            _ => None,
+        }
+    }
+
+    pub const fn to_set(self) -> (u32, u32) {
+        (self.width.get(), self.height.get())
+    }
+
+    /// Same size for signed integer requests, capped at [`i32::MAX`]
+    /// so the value can never become negative on the set.
+    pub const fn to_set_i32(self) -> (i32, i32) {
+        const fn clamp(value: u32) -> i32 {
+            if value > i32::MAX as u32 {
+                i32::MAX
+            } else {
+                value as i32
+            }
+        }
+        (clamp(self.width.get()), clamp(self.height.get()))
+    }
+}
+
+/// check if positive exclusive zone is meaningful for anchor
+pub(crate) fn exclusive_zone_is_meaningful(anchor: Anchor) -> bool {
+    let spans_horizontally = anchor.contains(HORIZONTAL_EDGES);
+    let spans_vertically = anchor.contains(VERTICAL_EDGES);
+    match (spans_horizontally, spans_vertically) {
+        // all four edges: no free edge to reserve space from
+        (true, true) => false,
+        // an edge plus both perpendicular edges
+        (true, false) => anchor.intersects(VERTICAL_EDGES),
+        (false, true) => anchor.intersects(HORIZONTAL_EDGES),
+        // a corner, or nothing, invalid
+        (false, false) => anchor.bits().count_ones() == 1,
+    }
+}
+
+/// warn on positive zone paired with anchor the compositor clamps to zero.
+pub(crate) fn warn_if_exclusive_zone_ignored(zone: i32, anchor: Anchor) {
+    if zone > 0 && !exclusive_zone_is_meaningful(anchor) {
+        log::warn!(
+            "exclusive zone {zone} treated as 0: {anchor:?} is not a single edge, \
+             or an edge with both perpendicular ones"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: Anchor = HORIZONTAL_EDGES.union(VERTICAL_EDGES);
+
+    #[test]
+    fn exclusive_zone_meaningfulness_follows_the_spec() {
+        // one edge, and an edge with both perpendicular ones - either axis
+        for anchor in [
+            Anchor::Bottom,
+            Anchor::Bottom | Anchor::Left | Anchor::Right,
+            Anchor::Left | Anchor::Top | Anchor::Bottom,
+        ] {
+            assert!(exclusive_zone_is_meaningful(anchor), "{anchor:?}");
+        }
+        // nothing, a corner, two parallel edges, all four
+        for anchor in [
+            Anchor::empty(),
+            Anchor::Top | Anchor::Left,
+            Anchor::Left | Anchor::Right,
+            Anchor::Top | Anchor::Bottom,
+            ALL,
+        ] {
+            assert!(!exclusive_zone_is_meaningful(anchor), "{anchor:?}");
+        }
+    }
+
+    /// `0` at run-time is an `Option` to handle, not a panic
+    #[test]
+    fn a_zero_is_rejected_or_spelled_out() {
+        assert_eq!(Extent::try_px(0), None);
+        assert_eq!(PixelSize::try_px(0, 10), None);
+        assert_eq!(PixelSize::try_px(10, 0), None);
+        assert!(PixelSize::try_px(10, 10).is_some());
+    }
+}


### PR DESCRIPTION
PR to provide better guards for size & anchor values passed to lib. previously had to zero-guard dynamic values on client side when it should be on lib side.