### PR TITLE
feat: xdg_popup::reposition

### DIFF
--- a/exwlshellev/src/events.rs
+++ b/exwlshellev/src/events.rs
@@ -141,6 +141,22 @@ pub struct NewPopUpSettings {
     /// Serial of the input event
     pub grab_serial: Option<u32>,
 }
+
+/// be used to move and resize a mapped popup
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PopUpRepositionSettings {
+    /// the new size of the popup
+    pub size: PixelSize,
+    /// How the popup is positioned relative to its parent surface
+    pub placement: PopupPlacement,
+    /// which point of the anchor rect the popup is anchored to
+    pub anchor: PopupAnchor,
+    /// the direction the popup grows from the anchor point
+    pub gravity: PopupGravity,
+    /// how the compositor may adjust (flip/slide/resize) the popup for off-screen cases
+    pub constraint_adjustment: PopupConstraintAdjustment,
+}
+
 /// Settings used to create a new xdg toplevel window.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct NewXdgWindowSettings {
@@ -207,6 +223,7 @@ pub enum ReturnData<INFO> {
     RequestSetCursorShape((String, WlPointer)),
     NewLayerShell((NewLayerShellSettings, id::Id, Option<INFO>)),
     NewPopUp((NewPopUpSettings, id::Id, Option<INFO>)),
+    PopUpReposition((PopUpRepositionSettings, id::Id)),
     NewXdgBase((NewXdgWindowSettings, id::Id, Option<INFO>)),
     NewInputPanel((NewInputPanelSettings, id::Id, Option<INFO>)),
     None,

--- a/exwlshellev/src/lib.rs
+++ b/exwlshellev/src/lib.rs
@@ -105,7 +105,7 @@ pub use events::NewInputPanelSettings;
 pub use events::NewLayerShellSettings;
 pub use events::NewXdgWindowSettings;
 pub use events::OutputOption;
-pub use events::{NewPopUpSettings, PopupPlacement};
+pub use events::{NewPopUpSettings, PopUpRepositionSettings, PopupPlacement};
 pub use sctk::output::OutputInfo;
 pub use waycrate_xkbkeycode::keyboard;
 pub use waycrate_xkbkeycode::xkb_keyboard;
@@ -169,7 +169,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
 
 use wayland_protocols::xdg::shell::client::{
     xdg_popup::{self, XdgPopup},
-    xdg_positioner::XdgPositioner,
+    xdg_positioner::{self, XdgPositioner},
     xdg_surface::{self, XdgSurface},
     xdg_toplevel::{self, XdgToplevel},
     xdg_wm_base::{self, XdgWmBase},
@@ -443,6 +443,7 @@ impl<T> WindowStateUnitBuilder<T> {
                 becreated: Default::default(),
                 configured,
                 blur_option: BlurOption::None,
+                pending_reposition: None,
                 effect: None,
                 // Unknown why it is 120
                 scale: 120,
@@ -554,6 +555,9 @@ pub struct WindowStateUnit<T> {
     configured: bool,
 
     blur_option: BlurOption,
+
+    /// Only meaningful for PopUp
+    pending_reposition: Option<u32>,
 
     scale: u32,
     request_flag: WindowStateUnitRequestFlag,
@@ -1964,6 +1968,13 @@ impl<T> Dispatch<xdg_popup::XdgPopup, ()> for WindowState<T> {
                     state.units[unit_index].request_close();
                 }
             }
+            xdg_popup::Event::Repositioned { token } => {
+                if let Some(unit) = state.units.iter_mut().find(|unit| unit.shell == *surface)
+                    && unit.pending_reposition == Some(token)
+                {
+                    unit.pending_reposition = None;
+                }
+            }
             _ => {}
         }
     }
@@ -2924,29 +2935,15 @@ impl<T: 'static> WindowState<T> {
                                     continue;
                                 };
                                 let wl_surface = wmcompositer.create_surface(&qh, ());
-                                let positioner = wmbase.create_positioner(&qh, ());
-                                let (width, height) = size.to_set_i32();
-                                positioner.set_size(width, height);
-                                // `Position` is a 1×1 anchor rect at the point;
-                                // `Anchored` uses the rect directly.
-                                match placement {
-                                    PopupPlacement::Position((px, py)) => {
-                                        positioner.set_anchor_rect(px, py, 1, 1)
-                                    }
-                                    PopupPlacement::Anchored {
-                                        position: (arx, ary),
-                                        size: rect,
-                                    } => {
-                                        let (arw, arh) = rect.to_set_i32();
-                                        positioner.set_anchor_rect(arx, ary, arw, arh)
-                                    }
-                                }
-                                positioner.set_anchor(anchor);
-                                positioner.set_gravity(gravity);
-                                positioner.set_constraint_adjustment(constraint_adjustment);
-                                if positioner.version() >= 3 {
-                                    positioner.set_reactive();
-                                }
+                                let positioner = build_positioner(
+                                    &wmbase,
+                                    &qh,
+                                    size,
+                                    placement,
+                                    anchor,
+                                    gravity,
+                                    constraint_adjustment,
+                                );
                                 let wl_xdg_surface = wmbase.get_xdg_surface(&wl_surface, &qh, ());
 
                                 let popup = match &window_state.units[index].shell {
@@ -2964,11 +2961,13 @@ impl<T: 'static> WindowState<T> {
                                             "popup parent {:?} is neither a layer surface nor a popup; skipping popup creation",
                                             id
                                         );
+                                        positioner.destroy();
                                         wl_xdg_surface.destroy();
                                         wl_surface.destroy();
                                         continue;
                                     }
                                 };
+                                positioner.destroy();
 
                                 match (window_state.seat_back.as_ref(), grab_serial) {
                                     (Some(seat), Some(serial)) => popup.grab(seat, serial),
@@ -3011,6 +3010,50 @@ impl<T: 'static> WindowState<T> {
                                     .becreated(true)
                                     .build(),
                                 );
+                            }
+                            ReturnData::PopUpReposition((
+                                PopUpRepositionSettings {
+                                    size,
+                                    placement,
+                                    anchor,
+                                    gravity,
+                                    constraint_adjustment,
+                                },
+                                id,
+                            )) => {
+                                let Some(unit) =
+                                    window_state.units.iter_mut().find(|unit| unit.id == id)
+                                else {
+                                    continue;
+                                };
+                                let Shell::PopUp((popup, _)) = &unit.shell else {
+                                    log::warn!(
+                                        target: "exwlshellev",
+                                        "reposition target {id:?} is not a popup; only popups can be repositioned"
+                                    );
+                                    continue;
+                                };
+                                if popup.version() < 3 {
+                                    log::warn!(
+                                        target: "exwlshellev",
+                                        "compositor offers xdg_popup v{}, reposition needs v3; leaving popup {id:?} as it is",
+                                        popup.version()
+                                    );
+                                    continue;
+                                }
+                                let positioner = build_positioner(
+                                    &wmbase,
+                                    &qh,
+                                    size,
+                                    placement,
+                                    anchor,
+                                    gravity,
+                                    constraint_adjustment,
+                                );
+                                let token = unit.pending_reposition.unwrap_or(0).wrapping_add(1);
+                                popup.reposition(&positioner, token);
+                                positioner.destroy();
+                                unit.pending_reposition = Some(token);
                             }
                             ReturnData::NewXdgBase((
                                 NewXdgWindowSettings {
@@ -3426,6 +3469,37 @@ impl<T: 'static> WindowState<T> {
             self.append_return_data(return_data);
         }
     }
+}
+
+fn build_positioner<T: 'static>(
+    wmbase: &XdgWmBase,
+    qh: &QueueHandle<WindowState<T>>,
+    size: PixelSize,
+    placement: PopupPlacement,
+    anchor: xdg_positioner::Anchor,
+    gravity: xdg_positioner::Gravity,
+    constraint_adjustment: xdg_positioner::ConstraintAdjustment,
+) -> XdgPositioner {
+    let positioner = wmbase.create_positioner(qh, ());
+    let (width, height) = size.to_set_i32();
+    positioner.set_size(width, height);
+    match placement {
+        PopupPlacement::Position((px, py)) => positioner.set_anchor_rect(px, py, 1, 1),
+        PopupPlacement::Anchored {
+            position: (arx, ary),
+            size: rect,
+        } => {
+            let (arw, arh) = rect.to_set_i32();
+            positioner.set_anchor_rect(arx, ary, arw, arh)
+        }
+    }
+    positioner.set_anchor(anchor);
+    positioner.set_gravity(gravity);
+    positioner.set_constraint_adjustment(constraint_adjustment);
+    if positioner.version() >= 3 {
+        positioner.set_reactive();
+    }
+    positioner
 }
 
 fn get_cursor_buffer(

--- a/iced_examples/counter_multi/src/main.rs
+++ b/iced_examples/counter_multi/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use iced::widget::{button, column, container, row, text, text_input};
 use iced::window::Id;
 use iced::{Alignment, Element, Event, Length, Task as Command, event};
-use iced_layershell::actions::{IcedNewMenuSettings, IcedXdgWindowSettings};
+use iced_layershell::actions::{IcedNewMenuSettings, IcedNewPopupSettings, IcedXdgWindowSettings};
 use iced_runtime::window::Action as WindowAction;
 use iced_runtime::{Action, task};
 
@@ -173,7 +173,7 @@ impl Counter {
                         self.ids.insert(id, WindowInfo::PopUp);
                         return Command::done(Message::NewMenu {
                             settings: IcedNewMenuSettings {
-                                size: PixelSize::px(100, 100),
+                                size: PixelSize::px(160, 120),
                                 gravity: PopupGravity::TopRight,
                             },
                             id,
@@ -283,16 +283,29 @@ impl Counter {
             return text("hello here is topbar").into();
         }
         if let Some(WindowInfo::PopUp) = self.id_info(id) {
-            return container(button("close PopUp").on_press(Message::Close(id)))
-                .center_x(Length::Fill)
-                .center_y(Length::Fill)
-                .style(|_theme| container::Style {
-                    background: Some(iced::Color::from_rgba(0., 0.5, 0.7, 0.6).into()),
-                    ..Default::default()
-                })
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .into();
+            return container(
+                column![
+                    button("close PopUp").on_press(Message::Close(id)),
+                    button("grow & move").on_press(Message::PopUpReposition {
+                        settings: IcedNewPopupSettings::at_position_on_current_surface(
+                            PixelSize::px(220, 220),
+                            (240, 120),
+                        ),
+                        id,
+                    }),
+                ]
+                .align_x(Alignment::Center)
+                .spacing(10),
+            )
+            .center_x(Length::Fill)
+            .center_y(Length::Fill)
+            .style(|_theme| container::Style {
+                background: Some(iced::Color::from_rgba(0., 0.5, 0.7, 0.6).into()),
+                ..Default::default()
+            })
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into();
         }
         let center = column![
             button("Increment").on_press(Message::IncrementPressed),

--- a/iced_exwlshell/src/actions.rs
+++ b/iced_exwlshell/src/actions.rs
@@ -169,6 +169,10 @@ pub enum ExwlShellCustomAction {
         settings: IcedNewPopupSettings,
         id: IcedId,
     },
+    /// During move/resize of a mapped popup `settings.parent` is ignored. Can't be reparented as per spec
+    PopUpReposition {
+        settings: IcedNewPopupSettings,
+    },
     NewMenu {
         settings: IcedNewMenuSettings,
         id: IcedId,

--- a/iced_exwlshell/src/multi_window.rs
+++ b/iced_exwlshell/src/multi_window.rs
@@ -17,8 +17,8 @@ use crate::{
     settings::Settings,
 };
 use exwlshellev::{
-    DispatchMessage, DisplayWrapper, ExWlShellEvent, NewPopUpSettings, PopupPlacement,
-    RefreshRequest, ReturnData, WindowState, WindowWrapper,
+    DispatchMessage, DisplayWrapper, ExWlShellEvent, NewPopUpSettings, PopUpRepositionSettings,
+    PopupPlacement, RefreshRequest, ReturnData, WindowState, WindowWrapper,
     id::Id as LayerShellId,
     reexport::{
         wayland_client::{WlCompositor, WlRegion},
@@ -926,6 +926,29 @@ where
                     popup_settings,
                     layer_shell_id,
                     Some(iced_id),
+                )));
+            }
+            ExwlShellCustomAction::PopUpReposition { settings } => {
+                let IcedNewPopupSettings {
+                    size,
+                    placement,
+                    anchor,
+                    gravity,
+                    constraint_adjustment,
+                    ..
+                } = settings;
+                let Some(ex_shell_id) = ex_shell_id else {
+                    return;
+                };
+                ev.append_return_data(ReturnData::PopUpReposition((
+                    PopUpRepositionSettings {
+                        size,
+                        placement,
+                        anchor,
+                        gravity,
+                        constraint_adjustment,
+                    },
+                    ex_shell_id,
                 )));
             }
             ExwlShellCustomAction::NewMenu {

--- a/iced_exwlshell_macros/src/lib.rs
+++ b/iced_exwlshell_macros/src/lib.rs
@@ -55,6 +55,8 @@ pub fn to_exwlshell_message(
             NewBaseWindow { settings: iced_exwlshell::actions::IcedXdgWindowSettings, id: iced_exwlshell::reexport::IcedId },
             /// Action request for new base popup
             NewPopUp { settings: iced_exwlshell::actions::IcedNewPopupSettings, id: iced_exwlshell::reexport::IcedId },
+            /// During move/resize of a mapped popup `settings.parent` is ignored. Can't be reparented as per spec
+            PopUpReposition { settings: iced_exwlshell::actions::IcedNewPopupSettings, id: iced_exwlshell::reexport::IcedId },
             /// Action request for new menu
             NewMenu { settings: iced_exwlshell::actions::IcedNewMenuSettings, id: iced_exwlshell::reexport::IcedId },
             /// Action request for new input panel
@@ -132,6 +134,7 @@ pub fn to_exwlshell_message(
                         Self::NewLayerShell {settings, id } => Ok(ExwlShellCustomActionWithId::new(None, ExwlShellCustomAction::NewLayerShell { settings, id })),
                         Self::NewBaseWindow {settings, id } => Ok(ExwlShellCustomActionWithId::new(None, ExwlShellCustomAction::NewBaseWindow { settings, id })),
                         Self::NewPopUp { settings, id } => Ok(ExwlShellCustomActionWithId::new(None, ExwlShellCustomAction::NewPopUp { settings, id })),
+                        Self::PopUpReposition { settings, id } => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::PopUpReposition { settings })),
                         Self::NewMenu { settings, id } => Ok(ExwlShellCustomActionWithId::new(None, ExwlShellCustomAction::NewMenu { settings, id })),
                         Self::NewInputPanel {settings, id } => Ok(ExwlShellCustomActionWithId::new(None, ExwlShellCustomAction::NewInputPanel { settings, id })),
                         Self::RemoveWindow(id) => Ok(ExwlShellCustomActionWithId::new(Some(id), ExwlShellCustomAction::RemoveWindow)),

--- a/iced_layershell/src/actions.rs
+++ b/iced_layershell/src/actions.rs
@@ -178,6 +178,10 @@ pub enum LayerShellCustomAction {
         settings: IcedNewPopupSettings,
         id: IcedId,
     },
+    /// During move/resize of a mapped popup `settings.parent` is ignored. Can't be reparented as per spec
+    PopUpReposition {
+        settings: IcedNewPopupSettings,
+    },
     NewMenu {
         settings: IcedNewMenuSettings,
         id: IcedId,

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -33,8 +33,8 @@ use iced_program::Program as IcedProgram;
 use iced_runtime::Action;
 use iced_runtime::user_interface;
 use layershellev::{
-    DispatchMessage, DisplayWrapper, LayerShellEvent, NewPopUpSettings, PopupPlacement,
-    RefreshRequest, ReturnData, WindowState, WindowWrapper,
+    DispatchMessage, DisplayWrapper, LayerShellEvent, NewPopUpSettings, PopUpRepositionSettings,
+    PopupPlacement, RefreshRequest, ReturnData, WindowState, WindowWrapper,
     id::Id as LayerShellId,
     reexport::{
         wayland_client::{WlCompositor, WlRegion},
@@ -900,6 +900,29 @@ where
                     popup_settings,
                     layer_shell_id,
                     Some(iced_id),
+                )));
+            }
+            LayerShellCustomAction::PopUpReposition { settings } => {
+                let IcedNewPopupSettings {
+                    size,
+                    placement,
+                    anchor,
+                    gravity,
+                    constraint_adjustment,
+                    ..
+                } = settings;
+                let Some(layer_shell_id) = layer_shell_id else {
+                    return;
+                };
+                ev.append_return_data(ReturnData::PopUpReposition((
+                    PopUpRepositionSettings {
+                        size,
+                        placement,
+                        anchor,
+                        gravity,
+                        constraint_adjustment,
+                    },
+                    layer_shell_id,
                 )));
             }
             LayerShellCustomAction::NewMenu {

--- a/iced_layershell_macros/src/lib.rs
+++ b/iced_layershell_macros/src/lib.rs
@@ -51,6 +51,8 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                 NewLayerShell { settings: iced_layershell::reexport::NewLayerShellSettings, id: iced_layershell::reexport::IcedId },
                 NewBaseWindow { settings: iced_layershell::actions::IcedXdgWindowSettings, id: iced_layershell::reexport::IcedId },
                 NewPopUp { settings: iced_layershell::actions::IcedNewPopupSettings, id: iced_layershell::reexport::IcedId },
+                /// During move/resize of a mapped popup `settings.parent` is ignored. Can't be reparented as per spec
+                PopUpReposition { settings: iced_layershell::actions::IcedNewPopupSettings, id: iced_layershell::reexport::IcedId },
                 NewMenu { settings: iced_layershell::actions::IcedNewMenuSettings, id: iced_layershell::reexport::IcedId },
                 NewInputPanel { settings: iced_layershell::reexport::NewInputPanelSettings, id: iced_layershell::reexport::IcedId },
                 RemoveWindow(iced_layershell::reexport::IcedId),
@@ -113,6 +115,7 @@ pub fn to_layer_message(attr: TokenStream2, input: TokenStream2) -> manyhow::Res
                             Self::NewLayerShell {settings, id } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::NewLayerShell { settings, id })),
                             Self::NewBaseWindow {settings, id } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::NewBaseWindow { settings, id })),
                             Self::NewPopUp { settings, id } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::NewPopUp { settings, id })),
+                            Self::PopUpReposition { settings, id } => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::PopUpReposition { settings })),
                             Self::NewMenu { settings, id } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::NewMenu { settings, id })),
                             Self::NewInputPanel {settings, id } => Ok(LayerShellCustomActionWithId::new(None, LayerShellCustomAction::NewInputPanel { settings, id })),
                             Self::RemoveWindow(id) => Ok(LayerShellCustomActionWithId::new(Some(id), LayerShellCustomAction::RemoveWindow)),

--- a/layershellev/src/events.rs
+++ b/layershellev/src/events.rs
@@ -141,6 +141,22 @@ pub struct NewPopUpSettings {
     /// Serial of the input event
     pub grab_serial: Option<u32>,
 }
+
+/// be used to move and resize a mapped popup
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PopUpRepositionSettings {
+    /// the new size of the popup
+    pub size: PixelSize,
+    /// How the popup is positioned relative to its parent surface
+    pub placement: PopupPlacement,
+    /// which point of the anchor rect the popup is anchored to
+    pub anchor: PopupAnchor,
+    /// the direction the popup grows from the anchor point
+    pub gravity: PopupGravity,
+    /// how the compositor may adjust (flip/slide/resize) the popup for off-screen cases
+    pub constraint_adjustment: PopupConstraintAdjustment,
+}
+
 /// Settings used to create a new xdg toplevel window.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct NewXdgWindowSettings {
@@ -205,6 +221,7 @@ pub enum ReturnData<INFO> {
     RequestSetCursorShape((String, WlPointer)),
     NewLayerShell((NewLayerShellSettings, id::Id, Option<INFO>)),
     NewPopUp((NewPopUpSettings, id::Id, Option<INFO>)),
+    PopUpReposition((PopUpRepositionSettings, id::Id)),
     NewXdgBase((NewXdgWindowSettings, id::Id, Option<INFO>)),
     NewInputPanel((NewInputPanelSettings, id::Id, Option<INFO>)),
     None,

--- a/layershellev/src/lib.rs
+++ b/layershellev/src/lib.rs
@@ -105,7 +105,7 @@ pub use events::NewInputPanelSettings;
 pub use events::NewLayerShellSettings;
 pub use events::NewXdgWindowSettings;
 pub use events::OutputOption;
-pub use events::{NewPopUpSettings, PopupPlacement};
+pub use events::{NewPopUpSettings, PopUpRepositionSettings, PopupPlacement};
 pub use sctk::output::OutputInfo;
 pub use waycrate_xkbkeycode::keyboard;
 pub use waycrate_xkbkeycode::xkb_keyboard;
@@ -165,7 +165,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
 
 use wayland_protocols::xdg::shell::client::{
     xdg_popup::{self, XdgPopup},
-    xdg_positioner::XdgPositioner,
+    xdg_positioner::{self, XdgPositioner},
     xdg_surface::{self, XdgSurface},
     xdg_toplevel::{self, XdgToplevel},
     xdg_wm_base::{self, XdgWmBase},
@@ -416,6 +416,7 @@ impl<T> WindowStateUnitBuilder<T> {
                 becreated: Default::default(),
                 configured,
                 blur_option: BlurOption::None,
+                pending_reposition: None,
                 effect: None,
                 // Unknown why it is 120
                 scale: 120,
@@ -527,6 +528,9 @@ pub struct WindowStateUnit<T> {
     configured: bool,
 
     blur_option: BlurOption,
+
+    /// Only meaningful for PopUp
+    pending_reposition: Option<u32>,
 
     scale: u32,
     request_flag: WindowStateUnitRequestFlag,
@@ -1894,6 +1898,13 @@ impl<T> Dispatch<xdg_popup::XdgPopup, ()> for WindowState<T> {
                     state.units[unit_index].request_close();
                 }
             }
+            xdg_popup::Event::Repositioned { token } => {
+                if let Some(unit) = state.units.iter_mut().find(|unit| unit.shell == *surface)
+                    && unit.pending_reposition == Some(token)
+                {
+                    unit.pending_reposition = None;
+                }
+            }
             _ => {}
         }
     }
@@ -2733,27 +2744,15 @@ impl<T: 'static> WindowState<T> {
                                 continue;
                             };
                             let wl_surface = wmcompositer.create_surface(&qh, ());
-                            let positioner = wmbase.create_positioner(&qh, ());
-                            let (width, height) = size.to_set_i32();
-                            positioner.set_size(width, height);
-                            match placement {
-                                PopupPlacement::Position((px, py)) => {
-                                    positioner.set_anchor_rect(px, py, 1, 1)
-                                }
-                                PopupPlacement::Anchored {
-                                    position: (arx, ary),
-                                    size: rect,
-                                } => {
-                                    let (arw, arh) = rect.to_set_i32();
-                                    positioner.set_anchor_rect(arx, ary, arw, arh)
-                                }
-                            }
-                            positioner.set_anchor(anchor);
-                            positioner.set_gravity(gravity);
-                            positioner.set_constraint_adjustment(constraint_adjustment);
-                            if positioner.version() >= 3 {
-                                positioner.set_reactive();
-                            }
+                            let positioner = build_positioner(
+                                &wmbase,
+                                &qh,
+                                size,
+                                placement,
+                                anchor,
+                                gravity,
+                                constraint_adjustment,
+                            );
                             let wl_xdg_surface = wmbase.get_xdg_surface(&wl_surface, &qh, ());
 
                             let popup = match &window_state.units[index].shell {
@@ -2775,11 +2774,13 @@ impl<T: 'static> WindowState<T> {
                                         "popup parent {:?} is neither a layer surface nor a popup; skipping popup creation",
                                         id
                                     );
+                                    positioner.destroy();
                                     wl_xdg_surface.destroy();
                                     wl_surface.destroy();
                                     continue;
                                 }
                             };
+                            positioner.destroy();
 
                             match (window_state.seat_back.as_ref(), grab_serial) {
                                 (Some(seat), Some(serial)) => popup.grab(seat, serial),
@@ -2821,6 +2822,50 @@ impl<T: 'static> WindowState<T> {
                                 .becreated(true)
                                 .build(),
                             );
+                        }
+                        ReturnData::PopUpReposition((
+                            PopUpRepositionSettings {
+                                size,
+                                placement,
+                                anchor,
+                                gravity,
+                                constraint_adjustment,
+                            },
+                            id,
+                        )) => {
+                            let Some(unit) =
+                                window_state.units.iter_mut().find(|unit| unit.id == id)
+                            else {
+                                continue;
+                            };
+                            let Shell::PopUp((popup, _)) = &unit.shell else {
+                                log::warn!(
+                                    target: "layershellev",
+                                    "reposition target {id:?} is not a popup; only popups can be repositioned"
+                                );
+                                continue;
+                            };
+                            if popup.version() < 3 {
+                                log::warn!(
+                                    target: "layershellev",
+                                    "compositor offers xdg_popup v{}, reposition needs v3; leaving popup {id:?} as it is",
+                                    popup.version()
+                                );
+                                continue;
+                            }
+                            let positioner = build_positioner(
+                                &wmbase,
+                                &qh,
+                                size,
+                                placement,
+                                anchor,
+                                gravity,
+                                constraint_adjustment,
+                            );
+                            let token = unit.pending_reposition.unwrap_or(0).wrapping_add(1);
+                            popup.reposition(&positioner, token);
+                            positioner.destroy();
+                            unit.pending_reposition = Some(token);
                         }
                         ReturnData::NewXdgBase((
                             NewXdgWindowSettings {
@@ -3244,6 +3289,37 @@ impl<T: 'static> WindowState<T> {
             self.append_return_data(return_data);
         }
     }
+}
+
+fn build_positioner<T: 'static>(
+    wmbase: &XdgWmBase,
+    qh: &QueueHandle<WindowState<T>>,
+    size: PixelSize,
+    placement: PopupPlacement,
+    anchor: xdg_positioner::Anchor,
+    gravity: xdg_positioner::Gravity,
+    constraint_adjustment: xdg_positioner::ConstraintAdjustment,
+) -> XdgPositioner {
+    let positioner = wmbase.create_positioner(qh, ());
+    let (width, height) = size.to_set_i32();
+    positioner.set_size(width, height);
+    match placement {
+        PopupPlacement::Position((px, py)) => positioner.set_anchor_rect(px, py, 1, 1),
+        PopupPlacement::Anchored {
+            position: (arx, ary),
+            size: rect,
+        } => {
+            let (arw, arh) = rect.to_set_i32();
+            positioner.set_anchor_rect(arx, ary, arw, arh)
+        }
+    }
+    positioner.set_anchor(anchor);
+    positioner.set_gravity(gravity);
+    positioner.set_constraint_adjustment(constraint_adjustment);
+    if positioner.version() >= 3 {
+        positioner.set_reactive();
+    }
+    positioner
 }
 
 fn get_cursor_buffer(


### PR DESCRIPTION
Add popup reposition that allows to reposition and resize popup without destroying and recreating it.
Also fix leak I previously PRed, I forgot to destroy positioner after popup creation.