### PR TITLE
fix: create compositor synchronously & opt-in keep_compositor_alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Current update is hudge, so [Migration Guide is provided](https://github.com/way
 - Feat: ext-workspace-v1 support behind the `workspace` feature: `workspace::listen()` and workspace requests
 - Feat: support ext-background-effect-v1 blur via `BlurOption`
 - Feat: xdg_popup reposition via `PopUpRepositionSettings`
+- Feat: add opt-in `Settings::keep_compositor_alive` keeping the compositor alive when the last surface closes toreduce next "first" surface spawn
 
 ## [0.19.1] - 2026-07-12
 ### Changed

--- a/docs/MIGRATION-19.1->20.0.md
+++ b/docs/MIGRATION-19.1->20.0.md
@@ -175,3 +175,9 @@ Requests (`activate`, `deactivate`, `remove`, `assign`, `create_workspace`) go
 on the snapshot and are capability-gated: check `WorkspaceCapabilities` /
 `GroupCapabilities` before showing UI. A snapshot outliving its protocol objects
 returns `RequestError::Gone`.
+
+## Keep compositor alive (new)
+
+`Settings::keep_compositor_alive` (default `true`) keeps compositor alive when
+the last surface closes instead of dropping it. Set it to `false` for programs that
+open rarely and the cold start delay doesn't matter, but GPU/RAM resources do.

--- a/iced_exwlshell/README.md
+++ b/iced_exwlshell/README.md
@@ -12,6 +12,10 @@ iced-exwlshelll provides all extra shell bindings on wayland for iced.
 
 With this crate, you can use iced to build your kde-shell, notification application, and etc.
 
+`Settings::keep_compositor_alive` (default `true`) keeps compositor alive when
+the last surface closes instead of dropping it. Set it to `false` for programs that
+open rarely and the cold start delay doesn't matter, but GPU/RAM resources do.
+
 ## Design
 
 Since iced cannot define custom system actions and custom system events now, though I have a pr for it https://github.com/iced-rs/iced/pull/2658, but now I can use trait for the Message and let it become my custom system events and custom system actions. What you need is just add `#[to_exwlshell_message]` to your message, Then you will get a lot of extra fields on you `Message`. 

--- a/iced_exwlshell/src/multi_window.rs
+++ b/iced_exwlshell/src/multi_window.rs
@@ -26,7 +26,6 @@ use exwlshellev::{
 };
 #[cfg(all(feature = "linux-theme-detection", target_os = "linux"))]
 use futures::StreamExt;
-use futures::{FutureExt, future::LocalBoxFuture};
 #[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
 use iced_core::theme::Mode;
 use iced_core::{
@@ -48,7 +47,6 @@ use std::{
     mem,
     os::fd::AsFd,
     sync::Arc,
-    task::Poll,
     time::Duration,
 };
 use window_manager::Window;
@@ -91,7 +89,6 @@ where
     P::Message: 'static + TryInto<ExwlShellCustomActionWithId, Error = P::Message>,
 {
     use exwlshellev::calloop::channel::channel;
-    use futures::task;
     let (message_sender, message_receiver) = channel::<Action<P::Message>>();
 
     let boot_span = iced_debug::boot();
@@ -183,12 +180,12 @@ where
         settings.fonts,
         system_theme,
         proxy_back,
+        settings.keep_compositor_alive,
     );
     let mut context_state = ContextState::Context(context);
     boot_span.finish();
 
     let mut waiting_layer_shell_events = VecDeque::new();
-    let mut task_context = task::Context::from_waker(task::noop_waker_ref());
 
     ev.running_with_proxy(message_receiver, move |event, ev, layer_shell_id| {
         let mut def_returndata = ReturnData::None;
@@ -244,18 +241,6 @@ where
             let mut need_continue = false;
             context_state = match std::mem::replace(&mut context_state, ContextState::None) {
                 ContextState::None => unreachable!("context state is taken but not returned"),
-                ContextState::Future(mut future) => {
-                    tracing::debug!("poll context future");
-                    match future.as_mut().poll(&mut task_context) {
-                        Poll::Ready(context) => {
-                            tracing::debug!("context future is ready");
-                            // context is ready, continue to run.
-                            need_continue = true;
-                            ContextState::Context(context)
-                        }
-                        Poll::Pending => ContextState::Future(future),
-                    }
-                }
                 ContextState::Context(context) => {
                     if let Some((layer_shell_id, layer_shell_event)) =
                         waiting_layer_shell_events.pop_front()
@@ -285,7 +270,6 @@ where
 enum ContextState<Context> {
     None,
     Context(Context),
-    Future(LocalBoxFuture<'static, Context>),
 }
 
 struct Context<P, E, C>
@@ -313,6 +297,7 @@ where
     messages: Vec<P::Message>,
     proxy: IcedProxy<Action<P::Message>>,
     time: Instant,
+    keep_compositor_alive: bool,
 }
 
 impl<P, E, C> Context<P, E, C>
@@ -333,6 +318,7 @@ where
         fonts: Vec<Cow<'static, [u8]>>,
         system_theme: iced_core::theme::Mode,
         proxy: IcedProxy<Action<P::Message>>,
+        keep_compositor_alive: bool,
     ) -> Self {
         Self {
             on_new_shell,
@@ -341,6 +327,7 @@ where
             runtime,
             system_theme,
             fonts,
+            keep_compositor_alive,
             compositor: Default::default(),
             window_manager: WindowManager::new(),
             cached_layer_dimensions: HashMap::new(),
@@ -355,15 +342,13 @@ where
         }
     }
 
-    async fn create_compositor(
-        mut self,
-        window: Arc<WindowWrapper>,
-        display: DisplayWrapper,
-    ) -> Self {
+    /// Create compositor synchronously. This is a one-time init that must finish
+    /// before the first frame can render. Copies iced_winit logic.
+    fn create_compositor(&mut self, window: Arc<WindowWrapper>, display: DisplayWrapper) {
         let shell = Shell::new(self.proxy.clone());
-        let mut new_compositor = C::new(self.compositor_settings, display, window.clone(), shell)
-            .await
-            .expect("Cannot create compositer");
+        let compositor_future = C::new(self.compositor_settings, display, window.clone(), shell);
+        let mut new_compositor =
+            futures::executor::block_on(compositor_future).expect("Cannot create compositor");
         for font in self.fonts.clone() {
             new_compositor.load_font(font);
         }
@@ -376,7 +361,6 @@ where
         } else {
             LayerShellClipboard::connect(&window)
         };
-        self
     }
 
     fn remove_compositor(&mut self) {
@@ -405,11 +389,9 @@ where
                 return (ContextState::Context(self), None);
             };
             tracing::debug!("creating compositor");
-            let context_state = ContextState::Future(
-                self.create_compositor(layer_shell_window.gen_wrapper(), ev.display_wrapper())
-                    .boxed_local(),
-            );
-            return (context_state, Some(layer_shell_event));
+            let window = layer_shell_window.gen_wrapper();
+            let display = ev.display_wrapper();
+            self.create_compositor(window, display);
         }
 
         match layer_shell_event {
@@ -730,7 +712,8 @@ where
                 status: iced_core::event::Status::Ignored,
             });
         // if now there is no windows now, then break the compositor, and unlink the clipboard
-        if self.window_manager.is_empty() {
+        // unless opted-in to keep the compositor alive
+        if self.window_manager.is_empty() && !self.keep_compositor_alive {
             self.remove_compositor();
         }
     }

--- a/iced_exwlshell/src/settings.rs
+++ b/iced_exwlshell/src/settings.rs
@@ -62,6 +62,11 @@ pub struct Settings {
     /// land on. Clone the same handle into `Broadcast::listen` to receive them.
     /// The default is a fresh one, which nothing is listening to.
     pub shell_broadcast: shell::ShellSender,
+
+    /// Keep the compositor alive when the last surface closes, instead of
+    /// dropping it. Avoids cold-start delay at the cost of idle GPU/RAM.
+    /// Defaults to `true`. Useful for daemons that show surfaces rarely.
+    pub keep_compositor_alive: bool,
 }
 impl Default for Settings {
     fn default() -> Self {
@@ -75,6 +80,7 @@ impl Default for Settings {
             virtual_keyboard_support: None,
             with_connection: None,
             shell_broadcast: shell::channel().0,
+            keep_compositor_alive: true,
         }
     }
 }

--- a/iced_layershell/README.md
+++ b/iced_layershell/README.md
@@ -13,6 +13,10 @@ With this crate, you can use iced to build your kde-shell, notification applicat
 
 To learn about surfaces the runtime creates for you, set the `on_new_shell` hook, which maps the new surface to a message of your own before its first frame is drawn. For the same information asynchronously, pass a `iced_wayland_subscriber::shell::channel()` sender to `Settings::shell_broadcast` and subscribe from the receiver. The same broadcast reports the monitors via `OutputAdded`, `OutputUpdated`, `OutputRemoved`, and which monitor each of your windows is on, through `WindowOutputChanged`. When a window is removed, listen to the iced window events.
 
+`Settings::keep_compositor_alive` (default `true`) keeps compositor alive when
+the last surface closes instead of dropping it. Set it to `false` for programs that
+open rarely and the cold start delay doesn't matter, but GPU/RAM resources do.
+
 ## Example
 
 ### Single Window iced_layershell

--- a/iced_layershell/src/multi_window.rs
+++ b/iced_layershell/src/multi_window.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 #[cfg(all(feature = "linux-theme-detection", target_os = "linux"))]
 use futures::StreamExt;
-use futures::{FutureExt, future::LocalBoxFuture};
 #[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
 use iced_core::theme::Mode;
 use iced_core::{
@@ -48,7 +47,6 @@ use std::{
     mem,
     os::fd::AsFd,
     sync::Arc,
-    task::Poll,
     time::Duration,
 };
 use window_manager::Window;
@@ -90,7 +88,6 @@ where
     P::Theme: DefaultStyle,
     P::Message: 'static + TryInto<LayerShellCustomActionWithId, Error = P::Message>,
 {
-    use futures::task;
     use layershellev::calloop::channel::channel;
     let (message_sender, message_receiver) = channel::<Action<P::Message>>();
 
@@ -183,12 +180,12 @@ where
         settings.fonts,
         system_theme,
         proxy_back,
+        settings.keep_compositor_alive,
     );
     let mut context_state = ContextState::Context(context);
     boot_span.finish();
 
     let mut waiting_layer_shell_events = VecDeque::new();
-    let mut task_context = task::Context::from_waker(task::noop_waker_ref());
 
     ev.running_with_proxy(message_receiver, move |event, ev, layer_shell_id| {
         let mut def_returndata = ReturnData::None;
@@ -244,18 +241,6 @@ where
             let mut need_continue = false;
             context_state = match std::mem::replace(&mut context_state, ContextState::None) {
                 ContextState::None => unreachable!("context state is taken but not returned"),
-                ContextState::Future(mut future) => {
-                    tracing::debug!("poll context future");
-                    match future.as_mut().poll(&mut task_context) {
-                        Poll::Ready(context) => {
-                            tracing::debug!("context future is ready");
-                            // context is ready, continue to run.
-                            need_continue = true;
-                            ContextState::Context(context)
-                        }
-                        Poll::Pending => ContextState::Future(future),
-                    }
-                }
                 ContextState::Context(context) => {
                     if let Some((layer_shell_id, layer_shell_event)) =
                         waiting_layer_shell_events.pop_front()
@@ -285,7 +270,6 @@ where
 enum ContextState<Context> {
     None,
     Context(Context),
-    Future(LocalBoxFuture<'static, Context>),
 }
 
 struct Context<P, E, C>
@@ -313,6 +297,7 @@ where
     messages: Vec<P::Message>,
     proxy: IcedProxy<Action<P::Message>>,
     time: Instant,
+    keep_compositor_alive: bool,
 }
 
 impl<P, E, C> Context<P, E, C>
@@ -333,6 +318,7 @@ where
         fonts: Vec<Cow<'static, [u8]>>,
         system_theme: iced_core::theme::Mode,
         proxy: IcedProxy<Action<P::Message>>,
+        keep_compositor_alive: bool,
     ) -> Self {
         Self {
             compositor_settings,
@@ -341,6 +327,7 @@ where
             shell_broadcast,
             system_theme,
             fonts,
+            keep_compositor_alive,
             compositor: Default::default(),
             window_manager: WindowManager::new(),
             cached_layer_dimensions: HashMap::new(),
@@ -355,15 +342,13 @@ where
         }
     }
 
-    async fn create_compositor(
-        mut self,
-        window: Arc<WindowWrapper>,
-        display: DisplayWrapper,
-    ) -> Self {
+    /// Create compositor synchronously. This is a one-time init that must finish
+    /// before the first frame can render. Copies iced_winit logic.
+    fn create_compositor(&mut self, window: Arc<WindowWrapper>, display: DisplayWrapper) {
         let shell = Shell::new(self.proxy.clone());
-        let mut new_compositor = C::new(self.compositor_settings, display, window.clone(), shell)
-            .await
-            .expect("Cannot create compositer");
+        let compositor_future = C::new(self.compositor_settings, display, window.clone(), shell);
+        let mut new_compositor =
+            futures::executor::block_on(compositor_future).expect("Cannot create compositor");
         for font in self.fonts.clone() {
             new_compositor.load_font(font);
         }
@@ -376,7 +361,6 @@ where
         } else {
             LayerShellClipboard::connect(&window)
         };
-        self
     }
 
     fn remove_compositor(&mut self) {
@@ -405,11 +389,9 @@ where
                 return (ContextState::Context(self), None);
             };
             tracing::debug!("creating compositor");
-            let context_state = ContextState::Future(
-                self.create_compositor(layer_shell_window.gen_wrapper(), ev.display_wrapper())
-                    .boxed_local(),
-            );
-            return (context_state, Some(layer_shell_event));
+            let window = layer_shell_window.gen_wrapper();
+            let display = ev.display_wrapper();
+            self.create_compositor(window, display);
         }
 
         match layer_shell_event {
@@ -732,7 +714,8 @@ where
                 status: iced_core::event::Status::Ignored,
             });
         // if now there is no windows now, then break the compositor, and unlink the clipboard
-        if self.window_manager.is_empty() {
+        // unless opted-in to keep the compositor alive
+        if self.window_manager.is_empty() && !self.keep_compositor_alive {
             self.remove_compositor();
         }
     }

--- a/iced_layershell/src/settings.rs
+++ b/iced_layershell/src/settings.rs
@@ -63,6 +63,11 @@ pub struct Settings {
     /// land on. Clone the same handle into `Broadcast::listen` to receive them.
     /// The default is a fresh one, which nothing is listening to.
     pub shell_broadcast: shell::ShellSender,
+
+    /// Keep the compositor alive when the last surface closes, instead of
+    /// dropping it. Avoids cold-start delay at the cost of idle GPU/RAM.
+    /// Defaults to `true`. Useful for daemons that show surfaces rarely.
+    pub keep_compositor_alive: bool,
 }
 impl Default for Settings {
     fn default() -> Self {
@@ -76,6 +81,7 @@ impl Default for Settings {
             virtual_keyboard_support: None,
             with_connection: None,
             shell_broadcast: shell::channel().0,
+            keep_compositor_alive: true,
         }
     }
 }

--- a/iced_sessionlock/src/multi_window.rs
+++ b/iced_sessionlock/src/multi_window.rs
@@ -7,7 +7,6 @@ use std::{
     borrow::Cow,
     collections::{HashMap, VecDeque},
     sync::Arc,
-    task::Poll,
 };
 
 use crate::{clipboard::SessionLockClipboard, conversion, error::Error};
@@ -38,7 +37,6 @@ use window_manager::Window;
 
 #[cfg(all(feature = "linux-theme-detection", target_os = "linux"))]
 use futures::StreamExt;
-use futures::{FutureExt, future::LocalBoxFuture};
 
 use crate::{event::IcedSessionLockEvent, proxy::IcedProxy, settings::Settings};
 
@@ -78,7 +76,6 @@ where
     P::Theme: DefaultStyle,
     P::Message: 'static + TryInto<UnLockAction, Error = P::Message>,
 {
-    use futures::task;
     use sessionlockev::calloop::channel::channel;
 
     let (message_sender, message_receiver) = channel::<Action<P::Message>>();
@@ -148,7 +145,6 @@ where
         .build()
         .expect("Seems sessionlock is not supported");
 
-    let mut task_context = task::Context::from_waker(task::noop_waker_ref());
     let context = Context::<
         P,
         <P as iced_program::Program>::Executor,
@@ -187,18 +183,6 @@ where
             let mut need_continue = false;
             context_state = match std::mem::replace(&mut context_state, ContextState::None) {
                 ContextState::None => unreachable!("context state is taken but not returned"),
-                ContextState::Future(mut future) => {
-                    tracing::debug!("poll context future");
-                    match future.as_mut().poll(&mut task_context) {
-                        Poll::Ready(context) => {
-                            tracing::debug!("context future is ready");
-                            // context is ready, continue to run.
-                            need_continue = true;
-                            ContextState::Context(context)
-                        }
-                        Poll::Pending => ContextState::Future(future),
-                    }
-                }
                 ContextState::Context(context) => {
                     if let Some((session_lock_id, session_lock_event)) =
                         waiting_session_lock_events.pop_front()
@@ -228,7 +212,6 @@ where
 enum ContextState<Context> {
     None,
     Context(Context),
-    Future(LocalBoxFuture<'static, Context>),
 }
 
 struct Context<P, E, C>
@@ -288,15 +271,13 @@ where
         }
     }
 
-    async fn create_compositor(
-        mut self,
-        window: Arc<WindowWrapper>,
-        display: DisplayWrapper,
-    ) -> Self {
+    /// Create compositor synchronously. This is a one-time init that must finish
+    /// before the first frame can render. Copies iced_winit logic.
+    fn create_compositor(&mut self, window: Arc<WindowWrapper>, display: DisplayWrapper) {
         let shell = Shell::new(self.proxy.clone());
-        let mut new_compositor = C::new(self.compositor_settings, display, window.clone(), shell)
-            .await
-            .expect("Cannot create compositer");
+        let compositor_future = C::new(self.compositor_settings, display, window.clone(), shell);
+        let mut new_compositor =
+            futures::executor::block_on(compositor_future).expect("Cannot create compositor");
         for font in self.fonts.clone() {
             new_compositor.load_font(font);
         }
@@ -309,7 +290,6 @@ where
         } else {
             SessionLockClipboard::connect(&window)
         };
-        self
     }
 
     fn remove_compositor(&mut self) {
@@ -337,11 +317,9 @@ where
                 return (ContextState::Context(self), None);
             };
             tracing::debug!("creating compositor");
-            let context_state = ContextState::Future(
-                self.create_compositor(layer_shell_window.gen_wrapper(), ev.display_wrapper())
-                    .boxed_local(),
-            );
-            return (context_state, Some(session_lock_event));
+            let window = layer_shell_window.gen_wrapper();
+            let display = ev.display_wrapper();
+            self.create_compositor(window, display);
         }
         match session_lock_event {
             IcedSessionLockEvent::Window(WindowEvent::Refresh) => {


### PR DESCRIPTION
- init compositor synchronously as there is no reason to over-complicate that. Also follows iced winit and lowers the delay on first surface open for daemon mode
- option not to kill compositor on last surface kill. Helps with "first" surface start on daemon. It has a cost in terms of gpu/ram, so made it opt-in instead of opt-out.

Also continuing conversation of previous PRs:
I would keep both listen and local top-level impl
Reason for that is not to complicate life for cross-platform devs who use winit of iced and keep an option to expand toplevel in the future for linux-only devs.
