### PR TITLE
feat(iced): make proc macros optional but enabled by default

### DIFF
--- a/iced_exwlshell/Cargo.toml
+++ b/iced_exwlshell/Cargo.toml
@@ -11,8 +11,9 @@ description = "The binding of extra shells on wayland for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["linux-theme-detection"]
+default = ["linux-theme-detection", "macros"]
 
+macros = ["dep:iced_exwlshell_macros"]
 debug = ["iced_debug/enable"]
 time-travel = ["iced_exdevtools/time-travel", "debug"]
 unconditional-rendering = []
@@ -25,7 +26,7 @@ iced_runtime.workspace = true
 iced_core.workspace = true
 iced_futures.workspace = true
 iced_graphics.workspace = true
-iced_exwlshell_macros.workspace = true
+iced_exwlshell_macros = { workspace = true, optional = true }
 iced_program.workspace = true
 iced_debug.workspace = true
 iced_exdevtools.workspace = true

--- a/iced_exwlshell/README.md
+++ b/iced_exwlshell/README.md
@@ -10,6 +10,16 @@ iced-exwlshelll provides all extra shell bindings on wayland for iced.
 - support sessionlock
 - support ext-virtual-keyboard
 
+## Cargo features
+
+The `macros` feature is enabled by default and re-exports
+`to_exwlshell_message`. Consumers that do not use the macro can skip its
+proc-macro dependencies while retaining theme detection like so:
+
+```toml
+iced_exwlshell = { version = "...", default-features = false, features = ["linux-theme-detection"] }
+```
+
 With this crate, you can use iced to build your kde-shell, notification application, and etc.
 
 ## Design

--- a/iced_exwlshell/src/lib.rs
+++ b/iced_exwlshell/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(test(attr(cfg(feature = "macros"))))]
 #![doc = include_str!("../README.md")]
 pub mod actions;
 pub mod build_pattern;
@@ -37,6 +38,7 @@ pub mod reexport {
 
 mod ime_preedit;
 
+#[cfg(feature = "macros")]
 pub use iced_exwlshell_macros::to_exwlshell_message;
 
 pub use error::Error;

--- a/iced_exwlshell/tests/test_macro.rs
+++ b/iced_exwlshell/tests/test_macro.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use iced_exwlshell::reexport::{Anchor, LayerSize};
 use iced_exwlshell::to_exwlshell_message;
 

--- a/iced_layershell/Cargo.toml
+++ b/iced_layershell/Cargo.toml
@@ -11,8 +11,9 @@ description = "layershell binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["linux-theme-detection"]
+default = ["linux-theme-detection", "macros"]
 
+macros = ["dep:iced_layershell_macros"]
 debug = ["iced_debug/enable"]
 time-travel = ["iced_exdevtools/time-travel", "debug"]
 unconditional-rendering = []
@@ -25,7 +26,7 @@ iced_runtime.workspace = true
 iced_core.workspace = true
 iced_futures.workspace = true
 iced_graphics.workspace = true
-iced_layershell_macros.workspace = true
+iced_layershell_macros = { workspace = true, optional = true }
 iced_program.workspace = true
 iced_debug.workspace = true
 iced_exdevtools.workspace = true

--- a/iced_layershell/README.md
+++ b/iced_layershell/README.md
@@ -9,6 +9,16 @@ iced-layershell provides binding for iced and layershell.
 - support to open new layershell and support popup window.
 - support ext-virtual-keyboard
 
+## Cargo features
+
+The `macros` feature is enabled by default and re-exports
+`to_layer_message`.  Consumers that do not use the macro can skip its
+proc-macro dependencies while retaining theme detection like so:
+
+```toml
+iced_layershell = { version = "...", default-features = false, features = ["linux-theme-detection"] }
+```
+
 With this crate, you can use iced to build your kde-shell, notification application, and etc.
 
 To learn about surfaces the runtime creates for you, set the `on_new_shell` hook, which maps the new surface to a message of your own before its first frame is drawn. For the same information asynchronously, pass a `iced_wayland_subscriber::shell::channel()` sender to `Settings::shell_broadcast` and subscribe from the receiver. The same broadcast reports the monitors via `OutputAdded`, `OutputUpdated`, `OutputRemoved`, and which monitor each of your windows is on, through `WindowOutputChanged`. When a window is removed, listen to the iced window events.

--- a/iced_layershell/src/build_pattern/application/time.rs
+++ b/iced_layershell/src/build_pattern/application/time.rs
@@ -13,8 +13,8 @@ use std::time::Instant;
 /// This constructor is useful to create animated applications that
 /// are _pure_ (e.g. without relying on side-effect calls like [`Instant::now`]).
 ///
-/// This function is the same as the timed in iced, and you also need to use
-/// [crate::to_layer_message] to mark the Message
+/// This function matches iced's timed constructor. Use `to_layer_message` to mark the
+/// message enum when the default `macros` feature is enabled.
 pub fn timed<State, Message, Theme, Renderer>(
     boot: impl BootFn<State, Message>,
     namespace: impl NameSpace,

--- a/iced_layershell/src/lib.rs
+++ b/iced_layershell/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(test(attr(cfg(feature = "macros"))))]
 #![doc = include_str!("../README.md")]
 pub mod actions;
 pub mod build_pattern;
@@ -38,6 +39,7 @@ pub mod reexport {
 
 mod ime_preedit;
 
+#[cfg(feature = "macros")]
 pub use iced_layershell_macros::to_layer_message;
 
 pub use error::Error;

--- a/iced_layershell/tests/test_macro.rs
+++ b/iced_layershell/tests/test_macro.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use iced_layershell::reexport::{Anchor, LayerSize};
 use iced_layershell::to_layer_message;
 

--- a/iced_sessionlock/Cargo.toml
+++ b/iced_sessionlock/Cargo.toml
@@ -11,15 +11,16 @@ description = "sessionlock binding for iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["linux-theme-detection"]
+default = ["linux-theme-detection", "macros"]
 
+macros = ["dep:iced_sessionlock_macros"]
 debug = ["iced_debug/enable"]
 time-travel = ["iced_exdevtools/time-travel", "debug"]
 unconditional-rendering = []
 linux-theme-detection = ["dep:mundy"]
 
 [dependencies]
-iced_sessionlock_macros.workspace = true
+iced_sessionlock_macros = { workspace = true, optional = true }
 iced_renderer.workspace = true
 iced_runtime.workspace = true
 iced_core.workspace = true

--- a/iced_sessionlock/README.md
+++ b/iced_sessionlock/README.md
@@ -6,6 +6,16 @@ iced-layershell provides binding for iced and sessionlock.
 
 Session lock is the wayland protocol for lock. This protocol is supported in river, sway and etc. We use it make a beautiful lock program in [twenty](https://github.com/waycrate/twenty). You can also use it to build your sessionlock. This will become very easy to use our crate with pam crate.
 
+## Cargo features
+
+The `macros` feature is enabled by default and re-exports
+`to_session_message`. Consumers that do not use the macro can skip its
+proc-macro dependencies while retaining theme detection like so:
+
+```toml
+iced_sessionlock = { version = "...", default-features = false, features = ["linux-theme-detection"] }
+```
+
 The smallest example is like
 
 ```rust, no_run

--- a/iced_sessionlock/src/lib.rs
+++ b/iced_sessionlock/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(test(attr(cfg(feature = "macros"))))]
 #![doc = include_str!("../README.md")]
 pub mod actions;
 pub mod build_pattern;
@@ -11,6 +12,7 @@ mod event;
 mod proxy;
 mod user_interface;
 
+#[cfg(feature = "macros")]
 pub use iced_sessionlock_macros::to_session_message;
 
 pub use error::Error;

--- a/iced_sessionlock/tests/macro_test.rs
+++ b/iced_sessionlock/tests/macro_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use iced_sessionlock::to_session_message;
 
 #[test]


### PR DESCRIPTION
## Summary

Make the proc macros within `iced_layershell` and sister crates optional. Consumers that do not use the message macros can now avoid their proc-macro dependency chains, that's all.

Existing users with `default_features = false` who use macros must now enable macros explicitly, which might need to be added to the migration docs.