### PR TITLE
feat: add configurable redraw policy to iced_exwlshell

### DIFF
--- a/iced_examples/counter_multi/src/main.rs
+++ b/iced_examples/counter_multi/src/main.rs
@@ -4,6 +4,7 @@ use iced::widget::{button, column, container, row, text, text_input};
 use iced::window::Id;
 use iced::{Alignment, Element, Event, Length, Task as Command, event};
 use iced_exwlshell::actions::{IcedNewMenuSettings, IcedNewPopupSettings, IcedXdgWindowSettings};
+use iced_exwlshell::redraw::Scope;
 use iced_runtime::window::Action as WindowAction;
 use iced_runtime::{Action, task};
 
@@ -43,6 +44,7 @@ pub fn main() -> Result<(), iced_exwlshell::Error> {
         shell_broadcast,
         ..Default::default()
     })
+    .redraw_scope(redraw_scope)
     .run()
 }
 
@@ -83,8 +85,8 @@ enum WayEvent {
 #[to_layer_message(multi)]
 #[derive(Debug, Clone)]
 enum Message {
-    IncrementPressed,
-    DecrementPressed,
+    IncrementPressed(Id),
+    DecrementPressed(Id),
     NewWindowLeft,
     NewNormalWindow,
     Close(Id),
@@ -216,11 +218,11 @@ impl Counter {
                     id,
                 })
             }
-            Message::IncrementPressed => {
+            Message::IncrementPressed(_) => {
                 self.value += 1;
                 Command::none()
             }
-            Message::DecrementPressed => {
+            Message::DecrementPressed(_) => {
                 self.value -= 1;
                 Command::none()
             }
@@ -326,8 +328,8 @@ impl Counter {
             .into();
         }
         let center = column![
-            button("Increment").on_press(Message::IncrementPressed),
-            button("Decrement").on_press(Message::DecrementPressed),
+            button("Increment").on_press(Message::IncrementPressed(id)),
+            button("Decrement").on_press(Message::DecrementPressed(id)),
             text(self.value).size(50),
             button("newwindowLeft").on_press(Message::NewWindowLeft),
             button("new normal window").on_press(Message::NewNormalWindow),
@@ -362,5 +364,18 @@ impl Counter {
         .width(Length::Fill)
         .height(Length::Fill)
         .into()
+    }
+}
+
+fn redraw_scope(message: &Message) -> Scope {
+    match message {
+        Message::IncrementPressed(id) | Message::DecrementPressed(id) => Scope::Window(*id),
+        Message::Direction(d) => match d {
+            WindowDirection::Bottom(id)
+            | WindowDirection::Top(id)
+            | WindowDirection::Left(id)
+            | WindowDirection::Right(id) => Scope::Window(*id),
+        },
+        _ => Scope::All,
     }
 }

--- a/iced_exwlshell/src/build_pattern/daemon.rs
+++ b/iced_exwlshell/src/build_pattern/daemon.rs
@@ -7,6 +7,7 @@ use iced_runtime::Task;
 use crate::actions::ExwlShellCustomActionWithId;
 
 use crate::DefaultStyle;
+use crate::redraw::{Policy, Scope};
 use crate::settings::LayerShellSettings;
 
 use crate::Result;
@@ -150,6 +151,7 @@ pub struct Daemon<A: Program> {
     settings: Settings,
     namespace: String,
     on_new_shell: Option<crate::NewShellHook<A::Message>>,
+    redraw_policy: Policy<A::Message>,
 }
 
 pub fn daemon<State, Message, Theme, Renderer>(
@@ -237,6 +239,7 @@ where
         settings: Settings::default(),
         namespace: namespace.namespace(),
         on_new_shell: None,
+        redraw_policy: Policy::default(),
     }
 }
 
@@ -667,9 +670,10 @@ impl<P: Program> Daemon<P> {
     {
         let settings = self.settings;
         let on_new_shell = self.on_new_shell;
+        let redraw_policy = self.redraw_policy;
 
         #[cfg(all(feature = "debug", not(target_arch = "wasm32")))]
-        let (program, on_new_shell) = {
+        let (program, on_new_shell, redraw_policy) = {
             iced_debug::init(iced_debug::Metadata {
                 name: P::name(),
                 theme: None,
@@ -680,11 +684,20 @@ impl<P: Program> Daemon<P> {
                 Box::new(move |info| f(info).map(iced_exdevtools::Event::Program))
                     as Box<dyn Fn(ShellInfo) -> Option<_>>
             });
-            (super::attach(self.raw), hook)
+            (
+                super::attach(self.raw),
+                hook,
+                redraw_policy.for_wrapped_messages(
+                    |event: &iced_exdevtools::Event<P>| match event {
+                        iced_exdevtools::Event::Program(message) => Some(message),
+                        _ => None,
+                    },
+                ),
+            )
         };
 
         #[cfg(any(not(feature = "debug"), target_arch = "wasm32"))]
-        let program = self.raw;
+        let (program, redraw_policy) = (self.raw, redraw_policy);
         let renderer_settings = iced_graphics::Settings {
             default_font: settings.default_font,
             default_text_size: settings.default_text_size,
@@ -702,6 +715,7 @@ impl<P: Program> Daemon<P> {
             renderer_settings,
             false,
             on_new_shell,
+            redraw_policy,
         )
     }
 
@@ -772,6 +786,7 @@ impl<P: Program> Daemon<P> {
             settings: self.settings,
             namespace: self.namespace,
             on_new_shell: self.on_new_shell,
+            redraw_policy: self.redraw_policy,
         }
     }
     /// Sets the subscription logic of the [`Daemon`].
@@ -784,6 +799,7 @@ impl<P: Program> Daemon<P> {
             settings: self.settings,
             namespace: self.namespace,
             on_new_shell: self.on_new_shell,
+            redraw_policy: self.redraw_policy,
         }
     }
 
@@ -797,6 +813,7 @@ impl<P: Program> Daemon<P> {
             settings: self.settings,
             namespace: self.namespace,
             on_new_shell: self.on_new_shell,
+            redraw_policy: self.redraw_policy,
         }
     }
 
@@ -819,6 +836,7 @@ impl<P: Program> Daemon<P> {
             settings: self.settings,
             namespace: self.namespace,
             on_new_shell: self.on_new_shell,
+            redraw_policy: self.redraw_policy,
         }
     }
 
@@ -832,6 +850,7 @@ impl<P: Program> Daemon<P> {
             settings: self.settings,
             namespace: self.namespace,
             on_new_shell: self.on_new_shell,
+            redraw_policy: self.redraw_policy,
         }
     }
     /// Sets the executor of the [`Daemon`].
@@ -846,6 +865,15 @@ impl<P: Program> Daemon<P> {
             settings: self.settings,
             namespace: self.namespace,
             on_new_shell: self.on_new_shell,
+            redraw_policy: self.redraw_policy,
         }
+    }
+
+    /// Sets the redraw scope of the [`Daemon`].
+    ///
+    /// Messages redraw all surfaces unless this method is called.
+    pub fn redraw_scope(mut self, scope: impl Fn(&P::Message) -> Scope + 'static) -> Self {
+        self.redraw_policy = Policy::new(scope);
+        self
     }
 }

--- a/iced_exwlshell/src/build_pattern/layershell.rs
+++ b/iced_exwlshell/src/build_pattern/layershell.rs
@@ -17,6 +17,7 @@ mod pattern {
     use crate::actions::ExwlShellCustomActionWithId;
 
     use crate::DefaultStyle;
+    use crate::redraw::Policy;
     use crate::settings::LayerShellSettings;
 
     use crate::Result;
@@ -414,6 +415,7 @@ mod pattern {
                 renderer_settings,
                 false,
                 None,
+                Policy::default(),
             )
         }
 

--- a/iced_exwlshell/src/build_pattern/sessionlock.rs
+++ b/iced_exwlshell/src/build_pattern/sessionlock.rs
@@ -13,6 +13,7 @@ mod pattern {
     use crate::actions::ExwlShellCustomActionWithId;
 
     use crate::DefaultStyle;
+    use crate::redraw::Policy;
     use crate::settings::LayerShellSettings;
 
     use crate::Result;
@@ -407,6 +408,7 @@ mod pattern {
                 renderer_settings,
                 true,
                 None,
+                Policy::default(),
             )
         }
 

--- a/iced_exwlshell/src/lib.rs
+++ b/iced_exwlshell/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 mod event;
 mod multi_window;
 mod proxy;
+pub mod redraw;
 mod user_interface;
 
 pub mod settings;

--- a/iced_exwlshell/src/multi_window.rs
+++ b/iced_exwlshell/src/multi_window.rs
@@ -1,3 +1,4 @@
+use crate::redraw::{Policy, Targets};
 use crate::reexport::{PopupAnchor, PopupConstraintAdjustment};
 use crate::{
     DefaultStyle,
@@ -83,6 +84,7 @@ pub fn run<P>(
     compositor_settings: iced_graphics::Settings,
     lock: bool,
     on_new_shell: Option<crate::NewShellHook<P::Message>>,
+    redraw_policy: Policy<P::Message>,
 ) -> Result<(), Error>
 where
     P: IcedProgram + 'static,
@@ -182,6 +184,7 @@ where
         system_theme,
         proxy_back,
         settings.keep_compositor_alive,
+        redraw_policy,
     )
     .lock(lock);
     let mut context_state = ContextState::Context(context);
@@ -300,6 +303,7 @@ where
     proxy: IcedProxy<Action<P::Message>>,
     time: Instant,
     keep_compositor_alive: bool,
+    redraw_policy: Policy<P::Message>,
 }
 
 impl<P, E, C> Context<P, E, C>
@@ -321,6 +325,7 @@ where
         system_theme: iced_core::theme::Mode,
         proxy: IcedProxy<Action<P::Message>>,
         keep_compositor_alive: bool,
+        redraw_policy: Policy<P::Message>,
     ) -> Self {
         Self {
             on_new_shell,
@@ -341,6 +346,7 @@ where
             messages: Default::default(),
             proxy,
             time: Instant::now(),
+            redraw_policy,
         }
     }
 
@@ -1117,7 +1123,24 @@ where
         }
 
         if !self.messages.is_empty() {
-            ev.request_refresh_all(RefreshRequest::NextFrame);
+            match self.redraw_policy.targets(&self.messages) {
+                Targets::All => {
+                    ev.request_refresh_all(RefreshRequest::NextFrame);
+                }
+                Targets::None => {}
+                Targets::Window(id) => {
+                    if let Some(window) = self.window_manager.get(id) {
+                        ev.request_refresh(window.id, RefreshRequest::NextFrame);
+                    }
+                }
+                Targets::Windows(windows) => {
+                    windows.into_iter().for_each(|id| {
+                        if let Some(window) = self.window_manager.get(id) {
+                            ev.request_refresh(window.id, RefreshRequest::NextFrame);
+                        }
+                    });
+                }
+            }
             let (caches, application) = self.user_interfaces.extract_all();
 
             // Update application

--- a/iced_exwlshell/src/redraw.rs
+++ b/iced_exwlshell/src/redraw.rs
@@ -1,0 +1,96 @@
+use iced_core::window::Id;
+use std::fmt::Debug;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    None,
+    Window(Id),
+    All,
+}
+
+pub(crate) enum Targets {
+    None,
+    Window(Id),
+    All,
+    Windows(Vec<Id>),
+}
+
+type RedrawScopeFn<Message> = dyn Fn(&Message) -> Scope;
+
+pub(crate) struct Policy<Message> {
+    scope: Option<Box<RedrawScopeFn<Message>>>,
+}
+
+impl<Message> Policy<Message> {
+    pub(crate) fn new(scope: impl Fn(&Message) -> Scope + 'static) -> Self {
+        Self {
+            scope: Some(Box::new(scope)),
+        }
+    }
+
+    #[cfg(any(all(feature = "debug", not(target_arch = "wasm32")), test))]
+    pub(crate) fn for_wrapped_messages<Wrapped>(
+        self,
+        inner_message: impl for<'a> Fn(&'a Wrapped) -> Option<&'a Message> + 'static,
+    ) -> Policy<Wrapped>
+    where
+        Message: 'static,
+    {
+        let Some(scope) = self.scope else {
+            return Policy::default();
+        };
+
+        Policy::new(move |message| inner_message(message).map_or(Scope::All, &scope))
+    }
+
+    pub(crate) fn targets(&self, messages: &[Message]) -> Targets {
+        let Some(scope) = self.scope.as_ref() else {
+            return Targets::All;
+        };
+
+        let mut first_window = None;
+        let mut messages = messages.iter();
+        let mut windows = None;
+
+        for message in messages.by_ref() {
+            match scope(message) {
+                Scope::All => return Targets::All,
+                Scope::None => {}
+                Scope::Window(id) => match first_window {
+                    None => first_window = Some(id),
+                    Some(current) if current == id => {}
+                    Some(current) => {
+                        windows = Some(vec![current, id]);
+                        break;
+                    }
+                },
+            }
+        }
+
+        if let Some(mut windows) = windows {
+            for message in messages {
+                match scope(message) {
+                    Scope::Window(id) if !windows.contains(&id) => windows.push(id),
+                    Scope::All => return Targets::All,
+                    Scope::Window(_) | Scope::None => {}
+                }
+            }
+
+            return Targets::Windows(windows);
+        }
+
+        first_window.map_or(Targets::None, Targets::Window)
+    }
+}
+
+impl<Message> Default for Policy<Message> {
+    fn default() -> Self {
+        Self { scope: None }
+    }
+}
+
+impl<Message> Debug for Policy<Message> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Policy").finish_non_exhaustive()
+    }
+}


### PR DESCRIPTION
Resolves #403

Adds a configurable redraw policy for selecting all, one, or no target windows based on each message.
The existing redraw-all behavior remains the default.